### PR TITLE
Fix/team definition alert source escalation policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.08.2022, Version 1.6.4
+
+- fix [#22](https://github.com/iLert/terraform-provider-ilert/issues/22)
+
 ## 09.08.2022, Version 1.6.3
 
 - fix parameter error send_notification on automation rules

--- a/examples/alert_source/main.tf
+++ b/examples/alert_source/main.tf
@@ -81,7 +81,7 @@ resource "ilert_alert_source" "example_with_support_hours" {
 resource "ilert_alert_source" "example_email" {
   name              = "My Email Integration from terraform"
   integration_type  = "EMAIL"
-  email             = "myemail@marko.ilert.eu"
+  email             = "support2@yacut.ilertnow.com"
   escalation_policy = ilert_escalation_policy.example.id
 
   alert_creation = "OPEN_RESOLVE_ON_EXTRACTION"

--- a/examples/alert_source/main.tf
+++ b/examples/alert_source/main.tf
@@ -81,7 +81,7 @@ resource "ilert_alert_source" "example_with_support_hours" {
 resource "ilert_alert_source" "example_email" {
   name              = "My Email Integration from terraform"
   integration_type  = "EMAIL"
-  email             = "myemail@username.ilert.eu"
+  email             = "myemail@marko.ilert.eu"
   escalation_policy = ilert_escalation_policy.example.id
 
   alert_creation = "OPEN_RESOLVE_ON_EXTRACTION"
@@ -104,4 +104,11 @@ resource "ilert_alert_source" "example_email" {
     criteria = "CONTAINS_STRING"
     value    = "resolve"
   }
+
+  team {
+    id = 0000
+  }
+
+  # @ deprecated
+  # team = [0000]
 }

--- a/examples/alert_source/main.tf
+++ b/examples/alert_source/main.tf
@@ -1,18 +1,50 @@
-data "ilert_escalation_policy" "default" {
-  name = "Default"
+resource "ilert_user" "example" {
+  email      = "example@example.com"
+  username   = "example"
+  first_name = "example"
+  last_name  = "example"
+
+  mobile {
+    region_code = "DE"
+    number      = "+491758250853"
+  }
+
+  high_priority_notification_preference {
+    method = "EMAIL"
+    delay  = 0
+  }
+
+  low_priority_notification_preference {
+    method = "EMAIL"
+    delay  = 0
+  }
+
+  on_call_notification_preference {
+    method     = "EMAIL"
+    before_min = 60
+  }
+}
+
+resource "ilert_escalation_policy" "example" {
+  name = "example"
+
+  escalation_rule {
+    escalation_timeout = 15
+    user               = ilert_user.example.id
+  }
 }
 
 resource "ilert_alert_source" "example" {
   name              = "My Grafana Integration from terraform"
   integration_type  = "GRAFANA"
-  escalation_policy = data.ilert_escalation_policy.default.id
+  escalation_policy = ilert_escalation_policy.example.id
 }
 
 resource "ilert_alert_source" "example_with_support_hours" {
-  name                   = "My Grafana Integration from terraform with support hours"
-  integration_type       = "GRAFANA"
-  escalation_policy      = data.ilert_escalation_policy.default.id
-  incident_priority_rule = "HIGH_DURING_SUPPORT_HOURS"
+  name                = "My Grafana Integration from terraform with support hours"
+  integration_type    = "GRAFANA"
+  escalation_policy   = ilert_escalation_policy.example.id
+  alert_priority_rule = "HIGH_DURING_SUPPORT_HOURS"
 
   support_hours {
     timezone = "Europe/Berlin"
@@ -49,10 +81,10 @@ resource "ilert_alert_source" "example_with_support_hours" {
 resource "ilert_alert_source" "example_email" {
   name              = "My Email Integration from terraform"
   integration_type  = "EMAIL"
-  email             = "support2@yacut.ilertnow.com"
-  escalation_policy = data.ilert_escalation_policy.default.id
+  email             = "myemail@username.ilert.eu"
+  escalation_policy = ilert_escalation_policy.example.id
 
-  incident_creation = "OPEN_RESOLVE_ON_EXTRACTION"
+  alert_creation = "OPEN_RESOLVE_ON_EXTRACTION"
   resolve_key_extractor {
     field    = "EMAIL_SUBJECT"
     criteria = "ALL_TEXT_BEFORE"

--- a/examples/escalation_policy/main.tf
+++ b/examples/escalation_policy/main.tf
@@ -24,5 +24,5 @@ resource "ilert_escalation_policy" "example" {
   }
 
   # @deprecated
-  teams = [1751]
+  # teams = [0000]
 }

--- a/examples/escalation_policy/main.tf
+++ b/examples/escalation_policy/main.tf
@@ -18,4 +18,11 @@ resource "ilert_escalation_policy" "example" {
     escalation_timeout = 15
     user               = data.ilert_user.example.id
   }
+
+  team {
+    id = 0000
+  }
+
+  # @deprecated
+  teams = [1751]
 }

--- a/examples/user/main.tf
+++ b/examples/user/main.tf
@@ -6,7 +6,7 @@ resource "ilert_user" "example" {
 
   mobile {
     region_code = "DE"
-    number      = "+491234567890"
+    number      = "+491758250853"
   }
 
   high_priority_notification_preference {

--- a/ilert/resource_alert_source.go
+++ b/ilert/resource_alert_source.go
@@ -153,10 +153,29 @@ func resourceAlertSource() *schema.Resource {
 				}, false),
 			},
 			"teams": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Deprecated: "The field teams is deprecated! Please use team instead.",
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,
+				},
+			},
+			"team": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+					},
 				},
 			},
 			"heartbeat": {
@@ -523,6 +542,21 @@ func buildAlertSource(d *schema.ResourceData) (*ilert.AlertSource, error) {
 		for _, m := range vL {
 			v := int64(m.(int))
 			tms = append(tms, ilert.TeamShort{ID: v})
+		}
+		alertSource.Teams = tms
+	}
+	if val, ok := d.GetOk("team"); ok {
+		vL := val.([]interface{})
+		tms := make([]ilert.TeamShort, 0)
+		for _, m := range vL {
+			v := m.(map[string]interface{})
+			tm := ilert.TeamShort{
+				ID: int64(v["id"].(int)),
+			}
+			if v["name"] != nil && v["name"].(string) != "" {
+				tm.Name = v["name"].(string)
+			}
+			tms = append(tms, tm)
 		}
 		alertSource.Teams = tms
 	}

--- a/ilert/resource_escalation_policy.go
+++ b/ilert/resource_escalation_policy.go
@@ -56,10 +56,29 @@ func resourceEscalationPolicy() *schema.Resource {
 				},
 			},
 			"teams": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Deprecated: "The field teams is deprecated! Please use team instead.",
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,
+				},
+			},
+			"team": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+					},
 				},
 			},
 		},
@@ -130,6 +149,22 @@ func buildEscalationPolicy(d *schema.ResourceData) (*ilert.EscalationPolicy, err
 		for _, m := range vL {
 			v := int64(m.(int))
 			tms = append(tms, ilert.TeamShort{ID: v})
+		}
+		escalationPolicy.Teams = tms
+	}
+
+	if val, ok := d.GetOk("team"); ok {
+		vL := val.([]interface{})
+		tms := make([]ilert.TeamShort, 0)
+		for _, m := range vL {
+			v := m.(map[string]interface{})
+			tm := ilert.TeamShort{
+				ID: int64(v["id"].(int)),
+			}
+			if v["name"] != nil && v["name"].(string) != "" {
+				tm.Name = v["name"].(string)
+			}
+			tms = append(tms, tm)
 		}
 		escalationPolicy.Teams = tms
 	}

--- a/website/docs/r/alert_source.html.markdown
+++ b/website/docs/r/alert_source.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 - `heartbeat` - (Optional) A [heartbeat](#heartbeat-arguments) block. This option is required if `integration_type` is `HEARTBEAT`.
 - `support_hours` - (Optional) A [support_hours](#support-hours-arguments) block. This option is allowed if `incident_priority_rule` is `HIGH_DURING_SUPPORT_HOURS` or `LOW_DURING_SUPPORT_HOURS`.
 - `autotask_metadata` - (Optional) An [autotask metadata](#autotask-metadata-arguments) block. This option is required if `integration_type` is `AUTOTASK`.
-- `teams` - (Optional) A list of related team ids.
+- `team` - (Optional) One or more [team](#team-arguments) blocks.
 
 #### Heartbeat Arguments
 
@@ -97,6 +97,11 @@ The following arguments are supported:
 - `field` - The field of the email resolve predicate. Allowed values are `EMAIL_FROM`, `EMAIL_SUBJECT` and `EMAIL_BODY`.
 - `criteria` - The criteria of the email resolve predicate. Allowed values are `CONTAINS_ANY_WORDS`, `CONTAINS_NOT_WORDS`, `CONTAINS_STRING`, `CONTAINS_NOT_STRING`, `IS_STRING`, `IS_NOT_STRING`, `MATCHES_REGEX`, `MATCHES_NOT_REGEX`.
 - `value` - The value of the email resolve predicate.
+
+#### Team Arguments
+
+- `id` - (Required) The ID of the team.
+- `name` - (Optional) The name of the team.
 
 ### Support Hours Example
 

--- a/website/docs/r/escalation_policy.html.markdown
+++ b/website/docs/r/escalation_policy.html.markdown
@@ -46,7 +46,12 @@ The following arguments are supported:
 - `repeating` - (Optional) Indicates whether or not the escalation policy will repeat. Default: `true`.
 - `frequency` - (Optional) The number of times the escalation policy will repeat after reaching the end of its escalation. This option is allowed if `repeating` is `true`. Default: `1`.
 - `escalation_rule` - (Optional) One or more [escalation rule](#escalation-rule-arguments) blocks.
-- `teams` - (Optional) A list of related team ids.
+- `team` - (Optional) One or more [team](#team-arguments) blocks.
+
+#### Team Arguments
+
+- `id` - (Required) The ID of the team.
+- `name` - (Optional) The name of the team.
 
 #### Escalation Rule Arguments
 

--- a/website/docs/r/incident_template.html.markdown
+++ b/website/docs/r/incident_template.html.markdown
@@ -28,7 +28,7 @@ The following arguments are supported:
 - `summary` - (Optional) The summary of the incident.
 - `message` - (Optional) The message of the incident.
 - `send_notification` - (Optional) Indicates whether or not notifications should be sent.
-- `teams` - (Optional) One or more [team](#team-arguments) blocks.
+- `team` - (Optional) One or more [team](#team-arguments) blocks.
 
 #### Team Arguments
 


### PR DESCRIPTION
Fix issue #22 

- name of "team" is not set when applying multiple times, therefore no terraform change detects
- changing from "teams" field to "team" is possible without detecting any terraform changes now
   - this allows easier move from now deprecated "teams" field to "team" (terraform block instead of number list)
- fixed documentation for alert source and escalation policy
- updated examples