### PR TITLE
Fix/remove deprecated resource block declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 20.02.2023, Version 1.11.3
+
+- fix/remove-deprecated-schema in [#46](https://github.com/iLert/terraform-provider-ilert/pull/46)]
+  - addresses issue [[#45](https://github.com/iLert/terraform-provider-ilert/issues/45)]
+
 ## 08.02.2023, Version 1.11.2
 
 - fix/optional-username in [#44](https://github.com/iLert/terraform-provider-ilert/pull/44)

--- a/examples/e2e/module/alert_source.tf
+++ b/examples/e2e/module/alert_source.tf
@@ -2,5 +2,7 @@ resource "ilert_alert_source" "this" {
   name              = var.name
   integration_type  = "GRAFANA"
   escalation_policy = ilert_escalation_policy.this.id
-  teams             = [ilert_team.this.id]
+  team {
+    id = ilert_team.this.id
+  }
 }

--- a/examples/e2e/module/escalation_policy.tf
+++ b/examples/e2e/module/escalation_policy.tf
@@ -6,5 +6,7 @@ resource "ilert_escalation_policy" "this" {
     user               = ilert_user.this.id
   }
 
-  teams = [ilert_team.this.id]
+  team {
+    id = ilert_team.this.id
+  }
 }

--- a/examples/escalation_policy/main.tf
+++ b/examples/escalation_policy/main.tf
@@ -21,12 +21,12 @@ resource "ilert_escalation_policy" "example" {
 
   escalation_rule {
     escalation_timeout = 15
-    users = [{
+    users {
       id = data.ilert_user.example.id
-    }]
-    schedules = [{
+    }
+    schedules {
       id = data.ilert_schedule.example.id
-    }]
+    }
   }
 
   team {

--- a/examples/team/main.tf
+++ b/examples/team/main.tf
@@ -28,5 +28,7 @@ resource "ilert_alert_source" "example" {
   name              = "My Grafana Integration"
   integration_type  = "GRAFANA"
   escalation_policy = data.ilert_escalation_policy.default.id
-  teams             = [ilert_team.example.id]
+  team {
+    id = ilert_team.example.id
+  }
 }

--- a/website/docs/r/escalation_policy.html.markdown
+++ b/website/docs/r/escalation_policy.html.markdown
@@ -26,12 +26,12 @@ resource "ilert_escalation_policy" "example" {
 
   escalation_rule {
     escalation_timeout = 15
-    users = [{
+    users {
       id = data.ilert_user.example.id
-    }, ...]
-    schedules = [{
+    }
+    schedules {
       id = data.ilert_schedule.example.id
-    }, ...]
+    }
   }
 }
 

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -35,7 +35,9 @@ resource "ilert_alert_source" "example" {
   name              = "My Grafana Integration"
   integration_type  = "GRAFANA"
   escalation_policy = data.ilert_escalation_policy.default.id
-  teams             = [ilert_team.example.id]
+  team {
+    id = ilert_team.example.id
+  }
 }
 
 ```


### PR DESCRIPTION
- removes deprecated resource block declaration from examples and docs
- this previously caused confusion to users, adressing #45 
Info:

Deprecated, not usable:
```hcl
   ...
   users = [{
      id = ilert_user.example.id
   }]
   ...
```

Correct:
```hcl
   ...
   users {
      id = ilert_user.example1.id
   }
   users {
      id = ilert_user.example2.id
   }
   ...
```