### PR TITLE
Fix/status page missing field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
+## 03.03.2023, Version 1.11.4
+
+- fix/status-page-missing-field in [#49](https://github.com/iLert/terraform-provider-ilert/pull/49)
+  - addresses issue [#48](https://github.com/iLert/terraform-provider-ilert/issues/48)
+
 ## 20.02.2023, Version 1.11.3
 
-- fix/remove-deprecated-schema in [#46](https://github.com/iLert/terraform-provider-ilert/pull/46)]
-  - addresses issue [[#45](https://github.com/iLert/terraform-provider-ilert/issues/45)]
+- fix/remove-deprecated-schema in [#46](https://github.com/iLert/terraform-provider-ilert/pull/46)
+  - addresses issue [#45](https://github.com/iLert/terraform-provider-ilert/issues/45)
 
 ## 08.02.2023, Version 1.11.2
 

--- a/ilert/resource_status_page.go
+++ b/ilert/resource_status_page.go
@@ -75,6 +75,10 @@ func resourceStatusPage() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"activated": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"team": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -236,6 +240,10 @@ func buildStatusPage(d *schema.ResourceData) (*ilert.StatusPage, error) {
 
 	if val, ok := d.GetOk("logo_redirect_url"); ok {
 		statusPage.LogoRedirectUrl = val.(string)
+	}
+
+	if val, ok := d.GetOk("activated"); ok {
+		statusPage.Activated = val.(bool)
 	}
 
 	if val, ok := d.GetOk("team"); ok {
@@ -434,6 +442,7 @@ func resourceStatusPageRead(ctx context.Context, d *schema.ResourceData, m inter
 	d.Set("page_title", result.StatusPage.PageTitle)
 	d.Set("page_description", result.StatusPage.PageDescription)
 	d.Set("logo_redirect_url", result.StatusPage.LogoRedirectUrl)
+	d.Set("activated", result.StatusPage.Activated)
 
 	teams, err := flattenTeamShortList(result.StatusPage.Teams, d)
 	if err != nil {


### PR DESCRIPTION
- [missing field `activated` in resource `ilert_status_page` sometimes caused the provider to crash](https://github.com/iLert/terraform-provider-ilert/issues/48)

Hint: no behaviour was changed, field `activated` is a computed value and should not be set in a TF schema
