### PR TITLE
Fix/alert action jira types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 29.09.2023, Version 2.0.4
+
+- fix/alert-action-jira-types in [#54](https://github.com/iLert/terraform-provider-ilert/pull/54)
+
 ## 02.05.2023, Version 2.0.3
 
 - fix/status-page-missing-field-1 in [#53](https://github.com/iLert/terraform-provider-ilert/pull/53)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 29.09.2023, Version 2.0.4
 
-- fix/alert-action-jira-types in [#54](https://github.com/iLert/terraform-provider-ilert/pull/54)
+- fix/alert-action-jira-types in [#55](https://github.com/iLert/terraform-provider-ilert/pull/55)
 
 ## 02.05.2023, Version 2.0.3
 

--- a/ilert/resource_alert_action.go
+++ b/ilert/resource_alert_action.go
@@ -121,13 +121,6 @@ func resourceAlertAction() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "Task",
-							ValidateFunc: validation.StringInSlice([]string{
-								"Bug",
-								"Epic",
-								"Subtask",
-								"Story",
-								"Task",
-							}, false),
 						},
 						"body_template": {
 							Type:     schema.TypeString,


### PR DESCRIPTION
- remove incorrect validation of field `issue_type` for Jira alert action 
- closes ilert/terraform-provider-ilert#54