### PR TITLE
Fix/user preferences optional contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 23.10.2023, Version 2.1.1
+
+- fix/user-preferences-optional-contact in [#60](https://github.com/iLert/terraform-provider-ilert/pull/60)
+
 ## 09.10.2023, Version 2.1.0
 
 - feature/escalation-policy-new-fields in [#57](https://github.com/iLert/terraform-provider-ilert/pull/57)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 23.10.2023, Version 2.1.1
 
-- fix/user-preferences-optional-contact in [#60](https://github.com/iLert/terraform-provider-ilert/pull/60)
+- fix/user-preferences-optional-contact in [#60](https://github.com/iLert/terraform-provider-ilert/pull/61)
 
 ## 09.10.2023, Version 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 23.10.2023, Version 2.1.1
 
-- fix/user-preferences-optional-contact in [#60](https://github.com/iLert/terraform-provider-ilert/pull/61)
+- fix/user-preferences-optional-contact in [#61](https://github.com/iLert/terraform-provider-ilert/pull/61)
 
 ## 09.10.2023, Version 2.1.0
 

--- a/ilert/resource_user_alert_preference.go
+++ b/ilert/resource_user_alert_preference.go
@@ -24,7 +24,7 @@ func resourceUserAlertPreference() *schema.Resource {
 			},
 			"contact": {
 				Type:        schema.TypeList,
-				Required:    true,
+				Optional:    true,
 				Description: "Either UserEmailContact or UserPhoneNumberContact",
 				MinItems:    1,
 				MaxItems:    1,
@@ -90,20 +90,25 @@ func buildUserAlertPreference(d *schema.ResourceData) (*ilert.UserAlertPreferenc
 		Type:     alertType,
 	}
 
-	contactList := d.Get("contact").([]interface{})
-	contact := &ilert.UserContactShort{}
-	if len(contactList) > 0 && contactList[0] != nil {
-		cnt := contactList[0].(map[string]interface{})
-		contact.ID = int64(cnt["id"].(int))
-	}
-	preference.Contact = contact
-
 	user := d.Get("user").([]interface{})
 	userId := int64(-1)
 	if len(user) > 0 && user[0] != nil {
 		usr := user[0].(map[string]interface{})
 		id := int64(usr["id"].(int))
 		userId = id
+	}
+
+	if val, ok := d.GetOk("contact"); ok {
+		if preference.Method == "PUSH" {
+			return nil, nil, fmt.Errorf("[ERROR] Field 'contact' must not be set when method is 'PUSH'")
+		}
+		contactList := val.([]interface{})
+		contact := &ilert.UserContactShort{}
+		if len(contactList) > 0 && contactList[0] != nil {
+			cnt := contactList[0].(map[string]interface{})
+			contact.ID = int64(cnt["id"].(int))
+		}
+		preference.Contact = contact
 	}
 
 	return preference, ilert.Int64(userId), nil

--- a/ilert/resource_user_alert_preference.go
+++ b/ilert/resource_user_alert_preference.go
@@ -109,6 +109,10 @@ func buildUserAlertPreference(d *schema.ResourceData) (*ilert.UserAlertPreferenc
 			contact.ID = int64(cnt["id"].(int))
 		}
 		preference.Contact = contact
+	} else {
+		if preference.Method != "PUSH" {
+			return nil, nil, fmt.Errorf("[ERROR] Field 'contact' must be set when method is 'EMAIL', 'SMS', 'VOICE', 'WHATSAPP' or 'TELEGRAM'")
+		}
 	}
 
 	return preference, ilert.Int64(userId), nil

--- a/ilert/resource_user_duty_preference.go
+++ b/ilert/resource_user_duty_preference.go
@@ -24,7 +24,7 @@ func resourceUserDutyPreference() *schema.Resource {
 			},
 			"contact": {
 				Type:        schema.TypeList,
-				Required:    true,
+				Optional:    true,
 				Description: "Either UserEmailContact or UserPhoneNumberContact",
 				MinItems:    1,
 				MaxItems:    1,
@@ -90,20 +90,25 @@ func buildUserDutyPreference(d *schema.ResourceData) (*ilert.UserDutyPreference,
 		Type:      dutyType,
 	}
 
-	contactList := d.Get("contact").([]interface{})
-	contact := &ilert.UserContactShort{}
-	if len(contactList) > 0 && contactList[0] != nil {
-		cnt := contactList[0].(map[string]interface{})
-		contact.ID = int64(cnt["id"].(int))
-	}
-	preference.Contact = contact
-
 	user := d.Get("user").([]interface{})
 	userId := int64(-1)
 	if len(user) > 0 && user[0] != nil {
 		usr := user[0].(map[string]interface{})
 		id := int64(usr["id"].(int))
 		userId = id
+	}
+
+	if val, ok := d.GetOk("contact"); ok {
+		if preference.Method == "PUSH" {
+			return nil, nil, fmt.Errorf("[ERROR] Field 'contact' must not be set when method is 'PUSH'")
+		}
+		contactList := val.([]interface{})
+		contact := &ilert.UserContactShort{}
+		if len(contactList) > 0 && contactList[0] != nil {
+			cnt := contactList[0].(map[string]interface{})
+			contact.ID = int64(cnt["id"].(int))
+		}
+		preference.Contact = contact
 	}
 
 	return preference, ilert.Int64(userId), nil

--- a/ilert/resource_user_duty_preference.go
+++ b/ilert/resource_user_duty_preference.go
@@ -109,6 +109,10 @@ func buildUserDutyPreference(d *schema.ResourceData) (*ilert.UserDutyPreference,
 			contact.ID = int64(cnt["id"].(int))
 		}
 		preference.Contact = contact
+	} else {
+		if preference.Method != "PUSH" {
+			return nil, nil, fmt.Errorf("[ERROR] Field 'contact' must be set when method is 'EMAIL', 'SMS', 'VOICE', 'WHATSAPP' or 'TELEGRAM'")
+		}
 	}
 
 	return preference, ilert.Int64(userId), nil

--- a/ilert/resource_user_subscription_preference.go
+++ b/ilert/resource_user_subscription_preference.go
@@ -95,6 +95,10 @@ func buildUserSubscriptionPreference(d *schema.ResourceData) (*ilert.UserSubscri
 			contact.ID = int64(cnt["id"].(int))
 		}
 		preference.Contact = contact
+	} else {
+		if preference.Method != "PUSH" {
+			return nil, nil, fmt.Errorf("[ERROR] Field 'contact' must be set when method is 'EMAIL', 'SMS', 'VOICE', 'WHATSAPP' or 'TELEGRAM'")
+		}
 	}
 
 	return preference, ilert.Int64(userId), nil

--- a/ilert/resource_user_update_preference.go
+++ b/ilert/resource_user_update_preference.go
@@ -102,6 +102,10 @@ func buildUserUpdatePreference(d *schema.ResourceData) (*ilert.UserUpdatePrefere
 			contact.ID = int64(cnt["id"].(int))
 		}
 		preference.Contact = contact
+	} else {
+		if preference.Method != "PUSH" {
+			return nil, nil, fmt.Errorf("[ERROR] Field 'contact' must be set when method is 'EMAIL', 'SMS', 'VOICE', 'WHATSAPP' or 'TELEGRAM'")
+		}
 	}
 
 	return preference, ilert.Int64(userId), nil

--- a/ilert/resource_user_update_preference.go
+++ b/ilert/resource_user_update_preference.go
@@ -24,7 +24,7 @@ func resourceUserUpdatePreference() *schema.Resource {
 			},
 			"contact": {
 				Type:        schema.TypeList,
-				Required:    true,
+				Optional:    true,
 				Description: "Either UserEmailContact or UserPhoneNumberContact",
 				MinItems:    1,
 				MaxItems:    1,
@@ -83,20 +83,25 @@ func buildUserUpdatePreference(d *schema.ResourceData) (*ilert.UserUpdatePrefere
 		Type:   updateType,
 	}
 
-	contactList := d.Get("contact").([]interface{})
-	contact := &ilert.UserContactShort{}
-	if len(contactList) > 0 && contactList[0] != nil {
-		cnt := contactList[0].(map[string]interface{})
-		contact.ID = int64(cnt["id"].(int))
-	}
-	preference.Contact = contact
-
 	user := d.Get("user").([]interface{})
 	userId := int64(-1)
 	if len(user) > 0 && user[0] != nil {
 		usr := user[0].(map[string]interface{})
 		id := int64(usr["id"].(int))
 		userId = id
+	}
+
+	if val, ok := d.GetOk("contact"); ok {
+		if preference.Method == "PUSH" {
+			return nil, nil, fmt.Errorf("[ERROR] Field 'contact' must not be set when method is 'PUSH'")
+		}
+		contactList := val.([]interface{})
+		contact := &ilert.UserContactShort{}
+		if len(contactList) > 0 && contactList[0] != nil {
+			cnt := contactList[0].(map[string]interface{})
+			contact.ID = int64(cnt["id"].(int))
+		}
+		preference.Contact = contact
 	}
 
 	return preference, ilert.Int64(userId), nil

--- a/website/docs/r/user_alert_preference.html.markdown
+++ b/website/docs/r/user_alert_preference.html.markdown
@@ -44,7 +44,7 @@ resource "ilert_user_alert_preference" "example" {
 The following arguments are supported:
 
 - `method` - (Required) The method of the user alert preference. Allowed values are `EMAIL`, `SMS`, `VOICE`, `PUSH`, `WHATSAPP`, `TELEGRAM`.
-- `contact` - (Required) A [contact](#contact-arguments) block.
+- `contact` - (Optional) A [contact](#contact-arguments) block. Required when `method` is `EMAIL`, `SMS`, `VOICE`, `WHATSAPP`, `TELEGRAM`. Must not be set when `method` is `PUSH`.
 - `delay_min` - (Required) The delay of the notification in minutes. Must be a value between `0` and `120` (inclusive).
 - `type` - (Required) The notification type of the user alert preference. Allowed values are `HIGH_PRIORITY`, `LOW_PRIORITY`.
 - `user` - (Required) A [user](#user-arguments) block.

--- a/website/docs/r/user_duty_preference.html.markdown
+++ b/website/docs/r/user_duty_preference.html.markdown
@@ -44,7 +44,7 @@ resource "ilert_user_duty_preference" "example" {
 The following arguments are supported:
 
 - `method` - (Required) The method of the user duty preference. Allowed values are `EMAIL`, `SMS`, `VOICE`, `WHATSAPP`, `TELEGRAM`.
-- `contact` - (Required) A [contact](#contact-arguments) block.
+- `contact` - (Optional) A [contact](#contact-arguments) block. Required when `method` is `EMAIL`, `SMS`, `VOICE`, `WHATSAPP`, `TELEGRAM`. Must not be set when `method` is `PUSH`.
 - `before_min` - (Required) Determines how many minutes in advance the notification should happen. Allowed values are `0`, `15`, `30`, `60`, `180`, `360`, `720`, `1440`.
 - `type` - (Required) The notification type of the user duty preference. Allowed values are `ON_CALL`.
 - `user` - (Required) A [user](#user-arguments) block.

--- a/website/docs/r/user_subscription_preference.html.markdown
+++ b/website/docs/r/user_subscription_preference.html.markdown
@@ -42,7 +42,7 @@ resource "ilert_user_subscription_preference" "example" {
 The following arguments are supported:
 
 - `method` - (Required) The method of the user subscription preference. Allowed values are `EMAIL`, `SMS`, `PUSH`.
-- `contact` - (Required) A [contact](#contact-arguments) block.
+- `contact` - (Optional) A [contact](#contact-arguments) block. Required when `method` is `EMAIL`, `SMS`, `VOICE`, `WHATSAPP`, `TELEGRAM`. Must not be set when `method` is `PUSH`.
 - `user` - (Required) A [user](#user-arguments) block.
 
 #### User Arguments

--- a/website/docs/r/user_update_preference.html.markdown
+++ b/website/docs/r/user_update_preference.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 - `method` - (Required) The method of the user update preference. Allowed values are `EMAIL`, `SMS`, `PUSH`.
 - `type` - (Required) The notification type of the user update preference. Allowed values are `ALERT_ACCEPTED`, `ALERT_RESOLVED`, `ALERT_ESCALATED`.
-- `contact` - (Required) A [contact](#contact-arguments) block.
+- `contact` - (Optional) A [contact](#contact-arguments) block. Required when `method` is `EMAIL`, `SMS`, `VOICE`, `WHATSAPP`, `TELEGRAM`. Must not be set when `method` is `PUSH`.
 - `user` - (Required) A [user](#user-arguments) block.
 
 #### User Arguments


### PR DESCRIPTION
- fixes an error in user preference resources incorrectly requiring `contact` when `method` is `PUSH`