### PR TITLE
Fix/alert action delay sec validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 27.11.2023, Version 2.2.1
+
+- fix/alert-action-delay-sec-validation in [#65](https://github.com/iLert/terraform-provider-ilert/pull/65)
+
 ## 13.11.2023, Version 2.2.0
 
 - feature/alert-action-new-trigger-type-delaysec in [#63](https://github.com/iLert/terraform-provider-ilert/pull/63)

--- a/website/docs/r/alert_action.html.markdown
+++ b/website/docs/r/alert_action.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 - `alert_source` - (Required) An [alert source](#alert-source-arguments) block.
 - `connector` - (Required) A [connector](#connector-arguments) block.
 - `trigger_mode` - (Optional) The trigger mode of the alert action. Allowed values are `AUTOMATIC` or `MANUAL`. Default: `AUTOMATIC`.
-- `delay_sec` - (Optional) The number of seconds the alert action will be delayed when reacing end of escalation. Can only be set when one of `trigger_types` is set to `alert-escalation-ended`.
+- `delay_sec` - (Optional) The number of seconds the alert action will be delayed when reacing end of escalation. Can only be set when one of `trigger_types` is set to `alert-escalation-ended`. Must be either `0` or a value between `30` and `7200`.
 - `trigger_types` - (Optional if the `MANUAL` trigger mode and required if the `AUTOMATIC` trigger mode) A list of the trigger types. Allowed values are `alert-created`, `alert-assigned`, `alert-auto-escalated`, `alert-acknowledged`, `alert-raised`, `alert-comment-added`, `alert-escalation-ended`, `alert-resolved`, `alert-auto-resolved`, `alert-responder-added`, `alert-responder-removed`, `alert-channel-attached`, `alert-channel-detached`.
 - `datadog` - (Optional) A [datadog](#datadog-arguments) block.
 - `jira` - (Optional) A [jira](#jira-arguments) block.


### PR DESCRIPTION
- closes ilert/terraform-provider-ilert#64

- improves `delaySec` validation in alert action resource
   - now correctly respects API restrictions