### PR TITLE
Fix/alert action delay sec restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 15.12.2023, Version 2.3.1
+
+- fix/alert-action-delay-sec-restrictions in [#75](https://github.com/iLert/terraform-provider-ilert/pull/75)
+
 ## 12.12.2023, Version 2.3.0
 
 - feature/improve-error-logging in [#71](https://github.com/iLert/terraform-provider-ilert/pull/71)

--- a/ilert/resource_alert_action.go
+++ b/ilert/resource_alert_action.go
@@ -668,17 +668,9 @@ func buildAlertAction(d *schema.ResourceData) (*ilert.AlertAction, error) {
 	if val, ok := d.GetOk("trigger_types"); ok {
 		vL := val.([]interface{})
 		sL := make([]string, 0)
-		delaySec, delaySecExists := d.GetOk("delay_sec")
-		delaySecIsSet := delaySecExists || (delaySec != nil && delaySec.(int) == 0)
 		for _, m := range vL {
 			v := m.(string)
-			if v == ilert.AlertActionTriggerTypes.AlertEscalationEnded && !delaySecIsSet {
-				return nil, fmt.Errorf("[ERROR] Can't set alert action trigger type 'alert-escalation-ended' when field 'delay_sec' is not set")
-			}
 			sL = append(sL, v)
-		}
-		if !StringSliceContains(sL, "alert-escalation-ended") && delaySecIsSet {
-			return nil, fmt.Errorf("[ERROR] Can't set field 'delay_sec' when trigger types do not include type 'alert-escalation-ended'")
 		}
 		alertAction.TriggerTypes = sL
 	}

--- a/website/docs/r/alert_action.html.markdown
+++ b/website/docs/r/alert_action.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 - `alert_source` - (Required) An [alert source](#alert-source-arguments) block.
 - `connector` - (Required) A [connector](#connector-arguments) block.
 - `trigger_mode` - (Optional) The trigger mode of the alert action. Allowed values are `AUTOMATIC` or `MANUAL`. Default: `AUTOMATIC`.
-- `delay_sec` - (Optional) The number of seconds the alert action will be delayed when reacing end of escalation. Can only be set when one of `trigger_types` is set to `alert-escalation-ended`. Must be either `0` or a value between `30` and `7200`.
+- `delay_sec` - (Optional) The number of seconds the alert action will be delayed when reacing end of escalation. Must be either `0` or a value between `30` and `7200`.
 - `trigger_types` - (Optional if the `MANUAL` trigger mode and required if the `AUTOMATIC` trigger mode) A list of the trigger types. Allowed values are `alert-created`, `alert-assigned`, `alert-auto-escalated`, `alert-acknowledged`, `alert-raised`, `alert-comment-added`, `alert-escalation-ended`, `alert-resolved`, `alert-auto-resolved`, `alert-responder-added`, `alert-responder-removed`, `alert-channel-attached`, `alert-channel-detached`.
 - `datadog` - (Optional) A [datadog](#datadog-arguments) block.
 - `jira` - (Optional) A [jira](#jira-arguments) block.


### PR DESCRIPTION
- release restrictions on field `delay_sec` in alert action resource
- closes ilert/terraform-provider-ilert#64