### PR TITLE
Feature/new api resources pt.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 22.08.2024, Version 2.9.0
+
+- feature/new-api-resources in [#92](https://github.com/iLert/terraform-provider-ilert/pull/92)
+
 ## 24.07.2024, Version 2.8.6
 
 - fix/microsoft-teams-webhook-validation [#90](https://github.com/iLert/terraform-provider-ilert/pull/90)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 22.08.2024, Version 2.9.0
 
-- feature/new-api-resources in [#92](https://github.com/iLert/terraform-provider-ilert/pull/92)
+- feature/new-api-resources pt.1 in [#92](https://github.com/iLert/terraform-provider-ilert/pull/92)
 
 ## 24.07.2024, Version 2.8.6
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/iLert/terraform-provider-ilert
 
 go 1.19
 
+replace github.com/iLert/ilert-go/v3 => /Users/markosimon/Documents/workspace/ilert-go
+
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/iLert/ilert-go/v3 v3.8.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
-	github.com/iLert/ilert-go/v3 v3.8.3
+	github.com/iLert/ilert-go/v3 v3.9.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/iLert/terraform-provider-ilert
 
 go 1.19
 
-replace github.com/iLert/ilert-go/v3 => /Users/markosimon/Documents/workspace/ilert-go
-
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/iLert/ilert-go/v3 v3.8.3

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/iLert/ilert-go/v3 v3.8.3 h1:QY3aYHzQ4JDCP/36TMxwDKtsvMU1Rd7cPrVBN8VeVEA=
-github.com/iLert/ilert-go/v3 v3.8.3/go.mod h1:xHJ8qdmthK4HExcQOd3V5JARed/EBKTdX86MqrJ1yJ0=
+github.com/iLert/ilert-go/v3 v3.9.0 h1:i13Yv3JeK9ZEJYysR6hcHCDvMxx5xetuafVrdiJb6Ts=
+github.com/iLert/ilert-go/v3 v3.9.0/go.mod h1:xHJ8qdmthK4HExcQOd3V5JARed/EBKTdX86MqrJ1yJ0=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/ilert/resource_connector.go
+++ b/ilert/resource_connector.go
@@ -15,7 +15,7 @@ import (
 
 func resourceConnector() *schema.Resource {
 	// remove types with no or one specific standalone connector
-	connectorTypesAll := removeStringsFromSlice(ilert.ConnectorTypesAll, ilert.ConnectorTypes.Email, ilert.ConnectorTypes.MicrosoftTeamsBot, ilert.ConnectorTypes.Slack, ilert.ConnectorTypes.Webhook, ilert.ConnectorTypes.AutomationRule, ilert.ConnectorTypes.Telegram, ilert.ConnectorTypes.DingTalkAction, ilert.ConnectorTypes.MicrosoftTeamsWebhook)
+	connectorTypesAll := removeStringsFromSlice(ilert.ConnectorTypesAll, ilert.ConnectorTypes.Email, ilert.ConnectorTypes.MicrosoftTeamsBot, ilert.ConnectorTypes.Slack, ilert.ConnectorTypes.Webhook, ilert.ConnectorTypes.AutomationRule, ilert.ConnectorTypes.Telegram, ilert.ConnectorTypes.DingTalkAction, ilert.ConnectorTypes.MicrosoftTeamsWebhook, ilert.ConnectorTypes.SlackWebhook)
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/ilert/resource_metric.go
+++ b/ilert/resource_metric.go
@@ -301,12 +301,18 @@ func resourceMetricRead(ctx context.Context, d *schema.ResourceData, m interface
 	}
 
 	d.Set("unit_label", result.Metric.UnitLabel)
-	d.Set("metadata", []interface{}{map[string]interface{}{
-		"query": result.Metric.Metadata.Query,
-	}})
-	d.Set("data_source", []interface{}{map[string]interface{}{
-		"id": int(result.Metric.DataSource.ID),
-	}})
+
+	if result.Metric.Metadata != nil {
+		d.Set("metadata", []interface{}{map[string]interface{}{
+			"query": result.Metric.Metadata.Query,
+		}})
+	}
+
+	if result.Metric.DataSource != nil {
+		d.Set("data_source", []interface{}{map[string]interface{}{
+			"id": int(result.Metric.DataSource.ID),
+		}})
+	}
 
 	return nil
 }

--- a/ilert/resource_status_page.go
+++ b/ilert/resource_status_page.go
@@ -209,6 +209,25 @@ func resourceStatusPage() *schema.Resource {
 				ValidateFunc:  validation.StringInSlice(ilert.StatusPageAppearanceAll, false),
 				ConflictsWith: []string{"theme_mode"},
 			},
+			"email_whitelist": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"announcement": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"announcement_on_page": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"announcement_in_widget": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"metric": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -432,6 +451,28 @@ func buildStatusPage(d *schema.ResourceData) (*ilert.StatusPage, error) {
 		statusPage.Appearance = val.(string)
 	}
 
+	if val, ok := d.GetOk("email_whitelist"); ok {
+		vL := val.([]interface{})
+		sL := make([]string, 0)
+		for _, m := range vL {
+			v := m.(string)
+			sL = append(sL, v)
+		}
+		statusPage.EmailWhitelist = sL
+	}
+
+	if val, ok := d.GetOk("announcement"); ok {
+		statusPage.Announcement = val.(string)
+	}
+
+	if val, ok := d.GetOk("announcement_on_page"); ok {
+		statusPage.AnnouncementOnPage = val.(bool)
+	}
+
+	if val, ok := d.GetOk("announcement_in_widget"); ok {
+		statusPage.AnnouncementInWidget = val.(bool)
+	}
+
 	if val, ok := d.GetOk("metric"); ok {
 		vL := val.([]interface{})
 		mts := make([]ilert.Metric, 0)
@@ -590,6 +631,22 @@ func resourceStatusPageRead(ctx context.Context, d *schema.ResourceData, m inter
 
 	if _, ok := d.GetOk("appearance"); ok {
 		d.Set("appearance", result.StatusPage.Appearance)
+	}
+
+	if val, ok := d.GetOk("email_whitelist"); ok && val.([]interface{}) != nil && len(val.([]interface{})) > 0 {
+		d.Set("email_whitelist", result.StatusPage.EmailWhitelist)
+	}
+
+	if _, ok := d.GetOk("announcement"); ok {
+		d.Set("announcement", result.StatusPage.Announcement)
+	}
+
+	if _, ok := d.GetOk("announcement_on_page"); ok {
+		d.Set("announcement_on_page", result.StatusPage.AnnouncementOnPage)
+	}
+
+	if _, ok := d.GetOk("announcement_in_widget"); ok {
+		d.Set("announcement_in_widget", result.StatusPage.AnnouncementInWidget)
 	}
 
 	metrics, err := flattenMetricsList(result.StatusPage.Metrics, d)

--- a/ilert/resource_status_page.go
+++ b/ilert/resource_status_page.go
@@ -209,6 +209,24 @@ func resourceStatusPage() *schema.Resource {
 				ValidateFunc:  validation.StringInSlice(ilert.StatusPageAppearanceAll, false),
 				ConflictsWith: []string{"theme_mode"},
 			},
+			"metric": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"name": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringLenBetween(1, 255),
+						},
+					},
+				},
+			},
 		},
 		CreateContext: resourceStatusPageCreate,
 		ReadContext:   resourceStatusPageRead,
@@ -414,6 +432,22 @@ func buildStatusPage(d *schema.ResourceData) (*ilert.StatusPage, error) {
 		statusPage.Appearance = val.(string)
 	}
 
+	if val, ok := d.GetOk("metric"); ok {
+		vL := val.([]interface{})
+		mts := make([]ilert.Metric, 0)
+		for _, m := range vL {
+			v := m.(map[string]interface{})
+			mt := ilert.Metric{
+				ID: int64(v["id"].(int)),
+			}
+			if v["name"] != nil && v["name"].(string) != "" {
+				mt.Name = v["name"].(string)
+			}
+			mts = append(mts, mt)
+		}
+		statusPage.Metrics = mts
+	}
+
 	return statusPage, nil
 }
 
@@ -558,6 +592,14 @@ func resourceStatusPageRead(ctx context.Context, d *schema.ResourceData, m inter
 		d.Set("appearance", result.StatusPage.Appearance)
 	}
 
+	metrics, err := flattenMetricsList(result.StatusPage.Metrics, d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("metric", metrics); err != nil {
+		return diag.Errorf("error setting metrics: %s", err)
+	}
+
 	return nil
 }
 
@@ -668,6 +710,28 @@ func flattenServicesList(list []ilert.Service, d *schema.ResourceData) ([]interf
 	}
 	results := make([]interface{}, 0)
 	if val, ok := d.GetOk("service"); ok && val != nil {
+		vL := val.([]interface{})
+		for i, item := range list {
+			if vL != nil && i < len(vL) && vL[i] != nil {
+				result := make(map[string]interface{})
+				v := vL[i].(map[string]interface{})
+				result["id"] = item.ID
+				if item.Name != "" && v["name"] != nil && v["name"].(string) != "" {
+					result["name"] = item.Name
+				}
+				results = append(results, result)
+			}
+		}
+	}
+	return results, nil
+}
+
+func flattenMetricsList(list []ilert.Metric, d *schema.ResourceData) ([]interface{}, error) {
+	if list == nil {
+		return make([]interface{}, 0), nil
+	}
+	results := make([]interface{}, 0)
+	if val, ok := d.GetOk("metric"); ok && val != nil {
 		vL := val.([]interface{})
 		for i, item := range list {
 			if vL != nil && i < len(vL) && vL[i] != nil {

--- a/ilert/resource_status_page.go
+++ b/ilert/resource_status_page.go
@@ -452,13 +452,17 @@ func buildStatusPage(d *schema.ResourceData) (*ilert.StatusPage, error) {
 	}
 
 	if val, ok := d.GetOk("email_whitelist"); ok {
-		vL := val.([]interface{})
-		sL := make([]string, 0)
-		for _, m := range vL {
-			v := m.(string)
-			sL = append(sL, v)
+		if statusPage.Visibility == ilert.StatusPageVisibility.Private {
+			vL := val.([]interface{})
+			sL := make([]string, 0)
+			for _, m := range vL {
+				v := m.(string)
+				sL = append(sL, v)
+			}
+			statusPage.EmailWhitelist = sL
+		} else {
+			return nil, fmt.Errorf("[ERROR] Can't set email whitelist, as it is only allowed on private status pages")
 		}
-		statusPage.EmailWhitelist = sL
 	}
 
 	if val, ok := d.GetOk("announcement"); ok {

--- a/website/docs/r/alert_action.html.markdown
+++ b/website/docs/r/alert_action.html.markdown
@@ -87,6 +87,7 @@ The following arguments are supported:
 - `telegram` - (Optional) An [telegram](#telegram-arguments) block.
 - `microsoft_teams_bot` - (Optional) A [microsoft_teams_bot](#microsoft-teams-bot-arguments) block.
 - `microsoft_teams_webhook` - (Optional) A [microsoft_teams_webhook](#microsoft-teams-webhook-arguments) block.
+- `slack_webhook` - (Optional) A [slack_webhook](#slack-webhook-arguments) block.
 - `alert_filter` - (Optional) An [alert_filter](#alert-filter-arguments) block.
 - `team` - (Optional) One or more [team](#team-arguments) blocks.
 
@@ -219,7 +220,9 @@ The following arguments are supported:
 
 #### Microsoft teams webhook Arguments
 
-> See [the Microsoft teams bot integration documentation](https://docs.ilert.com/chatops/microsoft-teams/chat/workflows) for more details.
+- `url` - (Required) The workflow URL for the channel.
+
+#### Slack webhook Arguments
 
 - `url` - (Required) The workflow URL for the channel.
 
@@ -250,7 +253,7 @@ The following attributes are exported:
 
 ## Import
 
-Services can be imported using the `id`, e.g.
+Alert actions can be imported using the `id`, e.g.
 
 ```sh
 $ terraform import ilert_alert_action.main 123456789

--- a/website/docs/r/alert_action.html.markdown
+++ b/website/docs/r/alert_action.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 - `connector` - (Required) A [connector](#connector-arguments) block.
 - `trigger_mode` - (Optional) The trigger mode of the alert action. Allowed values are `AUTOMATIC` or `MANUAL`. Default: `AUTOMATIC`.
 - `delay_sec` - (Optional) The number of seconds the alert action will be delayed when reaching end of escalation. Can only be set when one of `trigger_types` is set to `alert-escalation-ended`. Must be either `0` or a value between `30` and `7200`.
-- `trigger_types` - (Optional if the `MANUAL` trigger mode and required if the `AUTOMATIC` trigger mode) A list of the trigger types. Allowed values are `alert-created`, `alert-assigned`, `alert-auto-escalated`, `alert-acknowledged`, `alert-raised`, `alert-comment-added`, `alert-escalation-ended`, `alert-resolved`, `alert-auto-resolved`, `alert-responder-added`, `alert-responder-removed`, `alert-channel-attached`, `alert-channel-detached`.
+- `trigger_types` - (Optional if the `MANUAL` trigger mode and required if the `AUTOMATIC` trigger mode) A list of the trigger types. Allowed values are `alert-created`, `alert-assigned`, `alert-auto-escalated`, `alert-acknowledged`, `alert-raised`, `alert-comment-added`, `alert-escalation-ended`, `alert-resolved`, `alert-auto-resolved`, `alert-responder-added`, `alert-responder-removed`, `alert-channel-attached`, `alert-channel-detached`, `v-alert-not-resolved`.
 - `jira` - (Optional) A [jira](#jira-arguments) block.
 - `servicenow` - (Optional) A [servicenow](#servicenow-arguments) block.
 - `slack` - (Optional) A [slack](#slack-arguments) block.

--- a/website/docs/r/alert_action.html.markdown
+++ b/website/docs/r/alert_action.html.markdown
@@ -69,7 +69,8 @@ The following arguments are supported:
 - `alert_source` - (Required) One or more [alert source](#alert-source-arguments) blocks.
 - `connector` - (Required) A [connector](#connector-arguments) block.
 - `trigger_mode` - (Optional) The trigger mode of the alert action. Allowed values are `AUTOMATIC` or `MANUAL`. Default: `AUTOMATIC`.
-- `delay_sec` - (Optional) The number of seconds the alert action will be delayed when reaching end of escalation. Can only be set when one of `trigger_types` is set to `alert-escalation-ended`. Must be either `0` or a value between `30` and `7200`.
+- `escalation_ended_delay_sec` - (Optional) The number of seconds the alert action will be delayed when reaching end of escalation. Should only be set when one of `trigger_types` is set to `alert-escalation-ended`. Must be either `0` or a value between `30` and `7200`.
+- `not_resolved_delay_sec` - (Optional) The number of seconds the alert action will be delayed when the alert is not resolved yet. Should only be set when one of `trigger_types` is set to `v-alert-not-resolved`. Must be either `0` or a value between `60` and `7200`.
 - `trigger_types` - (Optional if the `MANUAL` trigger mode and required if the `AUTOMATIC` trigger mode) A list of the trigger types. Allowed values are `alert-created`, `alert-assigned`, `alert-auto-escalated`, `alert-acknowledged`, `alert-raised`, `alert-comment-added`, `alert-escalation-ended`, `alert-resolved`, `alert-auto-resolved`, `alert-responder-added`, `alert-responder-removed`, `alert-channel-attached`, `alert-channel-detached`, `v-alert-not-resolved`.
 - `jira` - (Optional) A [jira](#jira-arguments) block.
 - `servicenow` - (Optional) A [servicenow](#servicenow-arguments) block.

--- a/website/docs/r/alert_source.html.markdown
+++ b/website/docs/r/alert_source.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 - `name` - (Required) The name of the alert source.
 - `integration_type` - (Required) The integration type of the alert source. Allowed values are `NAGIOS`, `ICINGA`, `EMAIL`, `SMS`, `API`, `CRN`, `HEARTBEAT`, `PRTG`, `PINGDOM`, `CLOUDWATCH`, `AWSPHD`, `STACKDRIVER`, `INSTANA`, `ZABBIX`, `SOLARWINDS`, `PROMETHEUS`, `NEWRELIC`, `GRAFANA`, `GITHUB`, `DATADOG`, `UPTIMEROBOT`, `APPDYNAMICS`, `DYNATRACE`, `TOPDESK`, `STATUSCAKE`, `MONITOR`, `TOOL`, `CHECKMK`, `AUTOTASK`, `AWSBUDGET`, `KENTIXAM`, `JIRA`, `CONSUL`, `ZAMMAD`, `SIGNALFX`, `SPLUNK`, `KUBERNETES`, `SEMATEXT`, `SENTRY`, `SUMOLOGIC`, `RAYGUN`, `MXTOOLBOX`, `ESWATCHER`, `AMAZONSNS`, `KAPACITOR`, `CORTEXXSOAR`, `SYSDIG`, `SERVERDENSITY`, `ZAPIER`, `SERVICENOW`, `SEARCHGUARD`, `AZUREALERTS`, `TERRAFORMCLOUD`, `ZENDESK`, `AUVIK`, `SENSU`, `NCENTRAL`, `JUMPCLOUD`, `SALESFORCE`, `GUARDDUTY`, `STATUSHUB`, `IXON`, `APIFORTRESS`, `FRESHSERVICE`, `APPSIGNAL`, `LIGHTSTEP`, `IBMCLOUDFUNCTIONS`, `CROWDSTRIKE`, `HUMIO`, `OHDEAR`, `MONGODBATLAS`, `GITLAB`.
 - `escalation_policy` - (Required) The escalation policy id used by this alert source.
-- `alert_creation` - (Optional) ilert receives events from your monitoring systems and can then create alerts in different ways. This option is recommended. Allowed values are `ONE_ALERT_PER_EMAIL`, `ONE_ALERT_PER_EMAIL_SUBJECT`, `ONE_PENDING_ALERT_ALLOWED`, `ONE_OPEN_ALERT_ALLOWED`, `OPEN_RESOLVE_ON_EXTRACTION`, `ONE_ALERT_GROUPED_PER_WINDOW`. `alert_grouping_window` must be defined when this field is set to `ONE_ALERT_GROUPED_PER_WINDOW`.
+- `alert_creation` - (Optional) ilert receives events from your monitoring systems and can then create alerts in different ways. This option is recommended. Allowed values are `ONE_ALERT_PER_EMAIL`, `ONE_ALERT_PER_EMAIL_SUBJECT`, `ONE_PENDING_ALERT_ALLOWED`, `ONE_OPEN_ALERT_ALLOWED`, `OPEN_RESOLVE_ON_EXTRACTION`, `ONE_ALERT_GROUPED_PER_WINDOW`, `INTELLIGENT_GROUPING`. `alert_grouping_window` must be defined when this field is set to `ONE_ALERT_GROUPED_PER_WINDOW` or `INTELLIGENT_GROUPING`.
 - `active` - (Optional) The state of the alert source. Default: `true`.
 - `alert_priority_rule` - (Optional) The alert priority rule. This option is recommended. Allowed values are `HIGH`, `LOW`, `HIGH_DURING_SUPPORT_HOURS`, `LOW_DURING_SUPPORT_HOURS`.
 - `auto_resolution_timeout` - (Optional) The auto resolution timeout. Allowed values are `PT10M`, `PT20M`, `PT30M`, `PT40M`, `PT50M`, `PT60M`, `PT90M`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `PT12H`, `PT24H` (`H` means hour and `M` means minute).
@@ -62,7 +62,9 @@ The following arguments are supported:
 - `routing_template` - (Optional) A routing [template](#template-arguments) block.
 - `link_template` - (Optional) One or more [link template](#link-template-arguments) block.
 - `priority_template` - (Optional) A [priority template](#priority-template-arguments) block.
-- `alert_grouping_window` - (Optional) The alert grouping time frame. Any alerts triggered within this time frame will be grouped together. This field has to be defined when `alert_creation` is set to `ONE_ALERT_GROUPED_PER_WINDOW`.
+- `alert_grouping_window` - (Optional) The alert grouping time frame. Any alerts triggered within this time frame will be grouped together. This field has to be defined when `alert_creation` is set to `ONE_ALERT_GROUPED_PER_WINDOW` or `INTELLIGENT_GROUPING`.
+- `score_threshold` - (Optional) Sets the score threshold. Indicates how similar alerts are to be grouped together. This field has to be defined when `alert_creation` is set to `INTELLIGENT_GROUPING`. Should be a floating point number between `0` and `1` (inclusive).
+- `event_filter` - (Optional) Defines event filter condition in ICL language. This is a code based implementation, more info on syntax: https://docs.ilert.com/rest-api/icl-ilert-condition-language. For block based configuration please use the web UI.
 
 #### Heartbeat Arguments
 

--- a/website/docs/r/connector.html.markdown
+++ b/website/docs/r/connector.html.markdown
@@ -131,7 +131,7 @@ The following attributes are exported:
 
 ## Import
 
-Services can be imported using the `id`, e.g.
+Connectors can be imported using the `id`, e.g.
 
 ```sh
 $ terraform import ilert_connector.main 123456789

--- a/website/docs/r/status_page.html.markdown
+++ b/website/docs/r/status_page.html.markdown
@@ -66,6 +66,10 @@ The following arguments are supported:
 - `account_wide_view` - (Optional) Indicates whether or not the status page should be shown account wide.
 - `structure` - (Optional) A [structure](#structure-arguments) block.
 - `appearance` - (Optional) The appearance of the status page. Allowed values are `LIGHT` and `DARK`.
+- `email_whitelist` - (Optional) One or more emails to whitelist. Enables login via email only.
+- `announcement` - (Optional) Sets the text for an announcement shown at the top of the status page and/or in a widget.
+- `announcement_on_page`- (Optional) Indicates whether the announcement is show at the top of the status page or not.
+- `announcement_in_widget`- (Optional) Indicates whether the announcement is also shown in the status widget.
 - `metric` - (Required) One or more [metric](#metric-arguments) blocks.
 
 #### Service Arguments

--- a/website/docs/r/status_page.html.markdown
+++ b/website/docs/r/status_page.html.markdown
@@ -66,6 +66,7 @@ The following arguments are supported:
 - `account_wide_view` - (Optional) Indicates whether or not the status page should be shown account wide.
 - `structure` - (Optional) A [structure](#structure-arguments) block.
 - `appearance` - (Optional) The appearance of the status page. Allowed values are `LIGHT` and `DARK`.
+- `metric` - (Required) One or more [metric](#metric-arguments) blocks.
 
 #### Service Arguments
 
@@ -93,6 +94,11 @@ The following arguments are supported:
 - `id` - (Required) The ID of the child. Must be a status page group id.
 - `type` - (Required) The type of the child. Allowed values are `SERVICE`.
 - `options` - (Optional) One or more options to provide for the child. Allowed values are `no-graph`.
+
+#### Metric Arguments
+
+- `id` - (Required) The ID of the metric.
+- `name` - (Optional) The name of the metric.
 
 ## Attributes Reference
 


### PR DESCRIPTION
- add new api resources/fields pt.1
  - alert action
    - deprecate `delaySec` in favor of more specific `escalationEndedDelaySec` and `notResolvedDelaySec`
    - new trigger type `AlertNotResolved`
    - new alert action type `SlackWebhook`
  - alert source
    - new alert grouping type `intelligentGrouping`
      - add field `scoreThreshold`
    - add event filter
  - status page
    - add email login via `emailWhitelist`
    - add `announcement` fields
    - add `metrics`