### PR TITLE
Fix/alert source filter operator drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 09.06.2026, Version 2.22.0
+
+- fix spurious filter_operator/resolve_filter_operator diff on non-email alert sources [#135](https://github.com/iLert/terraform-provider-ilert/pull/135)
+
 ## 05.06.2026, Version 2.21.0
 
 - bump `ilert-go` with improved API error transparency: non-JSON error responses now report status, server, request-id and a body snippet, transport failures are classified (timeout / DNS / TLS / connection), and transient intermediary (WAF/proxy) blocks are retried while genuine client errors fail fast [#138](https://github.com/iLert/terraform-provider-ilert/pull/138)

--- a/ilert/resource_alert_source.go
+++ b/ilert/resource_alert_source.go
@@ -1171,8 +1171,16 @@ func transformAlertSourceResource(alertSource *ilert.AlertSource, d *schema.Reso
 	d.Set("auto_resolution_timeout", alertSource.AutoResolutionTimeout)
 	d.Set("email_filtered", alertSource.EmailFiltered)
 	d.Set("email_resolve_filtered", alertSource.EmailResolveFiltered)
-	d.Set("filter_operator", alertSource.FilterOperator)
-	d.Set("resolve_filter_operator", alertSource.ResolveFilterOperator)
+	// Only set when the API returns a value. These deprecated fields apply to
+	// EMAIL sources only; for other integration types the API returns an empty
+	// value which would clobber the schema default ("AND") and cause a
+	// perpetual "+ filter_operator = AND" diff on every plan.
+	if alertSource.FilterOperator != "" {
+		d.Set("filter_operator", alertSource.FilterOperator)
+	}
+	if alertSource.ResolveFilterOperator != "" {
+		d.Set("resolve_filter_operator", alertSource.ResolveFilterOperator)
+	}
 	d.Set("status", alertSource.Status)
 	d.Set("integration_key", alertSource.IntegrationKey)
 	d.Set("integration_url", alertSource.IntegrationURL)

--- a/ilert/resource_alert_source_test.go
+++ b/ilert/resource_alert_source_test.go
@@ -40,3 +40,37 @@ func TestTransformAlertSourceResource_DoesNotPanicWhenAPIReturnsMoreTeamsThanSta
 		t.Fatalf("expected 2 teams in state, got %d", len(teams))
 	}
 }
+
+func TestTransformAlertSourceResource_DoesNotClobberFilterOperatorDefaultWhenAPIReturnsEmpty(t *testing.T) {
+	// filter_operator/resolve_filter_operator are deprecated fields with a schema
+	// default of "AND". The API returns them empty for non-email sources, so the
+	// read must not overwrite the "AND" already in state with "". Doing so causes
+	// a perpetual "+ filter_operator = AND" diff on every plan.
+	d := schema.TestResourceDataRaw(t, resourceAlertSource().Schema, map[string]any{
+		"name":                    "test-alert-source",
+		"integration_type":        "CLOUDWATCH",
+		"escalation_policy":       "1",
+		"filter_operator":         "AND",
+		"resolve_filter_operator": "AND",
+	})
+
+	alertSource := &ilertapi.AlertSource{
+		Name: "test-alert-source",
+		EscalationPolicy: &ilertapi.EscalationPolicy{
+			ID: 1,
+		},
+		FilterOperator:        "",
+		ResolveFilterOperator: "",
+	}
+
+	if err := transformAlertSourceResource(alertSource, d); err != nil {
+		t.Fatalf("unexpected error transforming alert source: %v", err)
+	}
+
+	if got := d.Get("filter_operator").(string); got != "AND" {
+		t.Fatalf("expected filter_operator to remain \"AND\", got %q", got)
+	}
+	if got := d.Get("resolve_filter_operator").(string); got != "AND" {
+		t.Fatalf("expected resolve_filter_operator to remain \"AND\", got %q", got)
+	}
+}


### PR DESCRIPTION
- fix spurious `filter_operator` / `resolve_filter_operator` diff on non-email alert sources

## Problem

Non-email alert sources (e.g. `CLOUDWATCH`) show a diff on `terraform plan` even with no config changes:

```hcl
# ilert_alert_source.this will be updated in-place
~ resource "ilert_alert_source" "this" {
    + filter_operator         = "AND"
    + resolve_filter_operator = "AND"
      # (unchanged attributes hidden)
  }

Plan: 0 to add, 1 to change, 0 to destroy.
```

`terraform apply` clears it, but the diff reappears whenever the source is changed outside Terraform, producing recurring noise and false positives in plan-only drift detection.

## Cause

`filter_operator` / `resolve_filter_operator` are deprecated fields with a schema `Default: "AND"`. For non-email sources the API may return these as null. On read, the provider overwrote the `"AND"` default in state with `""`, so the config default `"AND"` diffed against state `""`.

## Fix

Only call `d.Set` for `filter_operator` / `resolve_filter_operator` when the API returns a non-empty value, so a good value in state is not clobbered by the API's empty response. `""` is never a valid value (the schema validates `{AND, OR}`), so skipping it cannot suppress a real change.