### PR TITLE
Feature/alert source setup status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - fix spurious filter_operator/resolve_filter_operator diff on non-email alert sources [#135](https://github.com/iLert/terraform-provider-ilert/pull/135)
 - add `severity_template` (dynamic severity mapping) and `severity` (default severity) to the alert source resource in [#140](https://github.com/iLert/terraform-provider-ilert/pull/140)
+- mark Terraform-created alert sources as setup finished in [#141](https://github.com/iLert/terraform-provider-ilert/pull/141)
 
 ## 05.06.2026, Version 2.21.0
 

--- a/ilert/resource_alert_source.go
+++ b/ilert/resource_alert_source.go
@@ -1068,6 +1068,11 @@ func resourceAlertSourceCreate(ctx context.Context, d *schema.ResourceData, m an
 		return diag.FromErr(err)
 	}
 
+	// Sources created via Terraform are fully configured, so mark the setup as
+	// finished. Otherwise the API defaults setupStatus to CREATED and the UI
+	// shows a "Finish setup" prompt for an already complete alert source.
+	alertSource.SetupStatus = ilert.AlertSourceSetupStatuses.Finished
+
 	log.Printf("[DEBUG] Creating ilert alert source %s\n", alertSource.Name)
 	result := &ilert.CreateAlertSourceOutput{}
 	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {

--- a/ilert/resource_alert_source.go
+++ b/ilert/resource_alert_source.go
@@ -1059,19 +1059,29 @@ func buildAlertSource(d *schema.ResourceData) (*ilert.AlertSource, error) {
 	return alertSource, nil
 }
 
+// buildCreateAlertSource builds the alert source payload for a create request.
+// Sources created via Terraform are fully configured, so the setup status is
+// marked as finished. Otherwise the API defaults setupStatus to CREATED and the
+// UI shows a "Finish setup" prompt for an already complete alert source. This is
+// applied on create only (not update), so a source's setup status is not altered
+// by subsequent applies.
+func buildCreateAlertSource(d *schema.ResourceData) (*ilert.AlertSource, error) {
+	alertSource, err := buildAlertSource(d)
+	if err != nil {
+		return nil, err
+	}
+	alertSource.SetupStatus = ilert.AlertSourceSetupStatuses.Finished
+	return alertSource, nil
+}
+
 func resourceAlertSourceCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	client := m.(*ilert.Client)
 
-	alertSource, err := buildAlertSource(d)
+	alertSource, err := buildCreateAlertSource(d)
 	if err != nil {
 		log.Printf("[ERROR] Building alert source error %s", err.Error())
 		return diag.FromErr(err)
 	}
-
-	// Sources created via Terraform are fully configured, so mark the setup as
-	// finished. Otherwise the API defaults setupStatus to CREATED and the UI
-	// shows a "Finish setup" prompt for an already complete alert source.
-	alertSource.SetupStatus = ilert.AlertSourceSetupStatuses.Finished
 
 	log.Printf("[DEBUG] Creating ilert alert source %s\n", alertSource.Name)
 	result := &ilert.CreateAlertSourceOutput{}

--- a/ilert/resource_alert_source_test.go
+++ b/ilert/resource_alert_source_test.go
@@ -168,3 +168,23 @@ func TestBuildAlertSourceSeverity(t *testing.T) {
 		t.Fatalf("unexpected second mapping: %#v", st.Mappings[1])
 	}
 }
+
+func TestBuildCreateAlertSource_SetsSetupStatusFinished(t *testing.T) {
+	// Sources created via Terraform must be sent with setupStatus FINISHED so the
+	// API does not default them to CREATED (which surfaces a "Finish setup" prompt
+	// in the UI for an already complete alert source).
+	d := schema.TestResourceDataRaw(t, resourceAlertSource().Schema, map[string]any{
+		"name":              "test-alert-source",
+		"integration_type":  "CLOUDWATCH",
+		"escalation_policy": "1",
+	})
+
+	alertSource, err := buildCreateAlertSource(d)
+	if err != nil {
+		t.Fatalf("unexpected error building alert source: %v", err)
+	}
+
+	if alertSource.SetupStatus != ilertapi.AlertSourceSetupStatuses.Finished {
+		t.Fatalf("expected setup status %q, got %q", ilertapi.AlertSourceSetupStatuses.Finished, alertSource.SetupStatus)
+	}
+}


### PR DESCRIPTION
- mark Terraform-created alert sources as setup `FINISHED` so they no longer show a "Finish setup" prompt in the UI.