### PR TITLE
Fix/not resolved delay sec limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 16.06.2026, Version 2.22.1
+
+- raise `not_resolved_delay_sec` upper bound on the alert action resource from 7200 to 172800 (2 days) to match the iLert API/UI [#145](https://github.com/iLert/terraform-provider-ilert/pull/145)
+
 ## 09.06.2026, Version 2.22.0
 
 - fix spurious filter_operator/resolve_filter_operator diff on non-email alert sources [#135](https://github.com/iLert/terraform-provider-ilert/pull/135)

--- a/ilert/resource_alert_action.go
+++ b/ilert/resource_alert_action.go
@@ -998,8 +998,8 @@ func buildAlertAction(d *schema.ResourceData) (*ilert.AlertAction, error) {
 
 	if val, ok := d.GetOk("not_resolved_delay_sec"); ok {
 		notResolvedDelaySec := val.(int)
-		if notResolvedDelaySec != 0 && (notResolvedDelaySec < 60 || notResolvedDelaySec > 7200) {
-			return nil, fmt.Errorf("[ERROR] Can't set 'not_resolved_delay_sec', value must be either 0 or between 60 and 7200")
+		if notResolvedDelaySec != 0 && (notResolvedDelaySec < 60 || notResolvedDelaySec > 172800) {
+			return nil, fmt.Errorf("[ERROR] Can't set 'not_resolved_delay_sec', value must be either 0 or between 60 and 172800")
 		}
 		alertAction.NotResolvedDelaySec = val.(int)
 	}


### PR DESCRIPTION
- raise `not_resolved_delay_sec` upper bound on the alert action resource from 7200 to 172800 (2 days) to match the iLert API/UI