### PR TITLE
Feature/add documented api fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 20.07.2026, Version 2.23.0
+## 22.07.2026, Version 2.23.0
 
 - add documented `servicenow` (`close_code`, `assignment_group`, `owner_group`, `service`, `service_offering`, `contact_type`) and `autotask` (`note_type`, `note_publish`, `status`) alert action params, service `alias` and call flow `VOICEMAIL` `disable_transcription` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
 - add `VIEWER` to the user resource role and the team member role [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 20.07.2026, Version 2.23.0
 
 - add documented `servicenow` (`close_code`, `assignment_group`, `owner_group`, `service`, `service_offering`, `contact_type`) and `autotask` (`note_type`, `note_publish`, `status`) alert action params, service `alias` and call flow `VOICEMAIL` `disable_transcription` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
-- fix reading autotask alert actions and connections after `queue_id`/`company_id` became strings in `ilert-go` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
+- fix reading autotask alert actions and connections whose `queue_id`/`company_id` the API returns as strings [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
 
 ## 16.06.2026, Version 2.22.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 20.07.2026, Version 2.23.0
 
 - add documented `servicenow` (`close_code`, `assignment_group`, `owner_group`, `service`, `service_offering`, `contact_type`) and `autotask` (`note_type`, `note_publish`, `status`) alert action params, service `alias` and call flow `VOICEMAIL` `disable_transcription` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
+- add `VIEWER` to the user resource role and the team member role [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
 - fix reading autotask alert actions and connections whose `queue_id`/`company_id` the API returns as strings [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
 
 ## 16.06.2026, Version 2.22.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 22.07.2026, Version 2.23.0
+## 23.07.2026, Version 2.23.0
 
 - add documented `servicenow` (`close_code`, `assignment_group`, `owner_group`, `service`, `service_offering`, `contact_type`) and `autotask` (`note_type`, `note_publish`, `status`) alert action params, service `alias` and call flow `VOICEMAIL` `disable_transcription` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
 - add `VIEWER` to the user resource role and the team member role [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 20.07.2026, Version 2.23.0
+
+- add documented `servicenow` (`close_code`, `assignment_group`, `owner_group`, `service`, `service_offering`, `contact_type`) and `autotask` (`note_type`, `note_publish`, `status`) alert action params, service `alias` and call flow `VOICEMAIL` `disable_transcription` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
+- fix reading autotask alert actions after `queue_id`/`company_id` became strings in `ilert-go` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
+
 ## 16.06.2026, Version 2.22.1
 
 - raise `not_resolved_delay_sec` upper bound on the alert action resource from 7200 to 172800 (2 days) to match the iLert API/UI [#145](https://github.com/iLert/terraform-provider-ilert/pull/145)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 20.07.2026, Version 2.23.0
 
 - add documented `servicenow` (`close_code`, `assignment_group`, `owner_group`, `service`, `service_offering`, `contact_type`) and `autotask` (`note_type`, `note_publish`, `status`) alert action params, service `alias` and call flow `VOICEMAIL` `disable_transcription` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
-- fix reading autotask alert actions after `queue_id`/`company_id` became strings in `ilert-go` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
+- fix reading autotask alert actions and connections after `queue_id`/`company_id` became strings in `ilert-go` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)
 
 ## 16.06.2026, Version 2.22.1
 

--- a/examples/call_flow/main.tf
+++ b/examples/call_flow/main.tf
@@ -54,6 +54,7 @@ resource "ilert_call_flow" "always_on_support" {
                   text_message = "We're sorry, but all responders are currently unavailable. Please leave your name, contact information, and a brief message, and we'll get back to you as soon as possible."
                   ai_voice_model = "emma"
                   language = "en"
+                  disable_transcription = true
                 }
                 branches {
                   branch_type = "BRANCH"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
-	github.com/iLert/ilert-go/v3 v3.22.0
+	github.com/iLert/ilert-go/v3 v3.23.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/iLert/ilert-go/v3 v3.22.0 h1:Inr6BnujWTmLT7BQQj0rUdqRQFt7aH/7XOvdFpRoRdQ=
-github.com/iLert/ilert-go/v3 v3.22.0/go.mod h1:xHJ8qdmthK4HExcQOd3V5JARed/EBKTdX86MqrJ1yJ0=
+github.com/iLert/ilert-go/v3 v3.23.0 h1:tYJ5BePXjGtT8yT5AB5ePyycYGLaPMn1ynWxwBoMnHc=
+github.com/iLert/ilert-go/v3 v3.23.0/go.mod h1:xHJ8qdmthK4HExcQOd3V5JARed/EBKTdX86MqrJ1yJ0=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/ilert/data_source_service.go
+++ b/ilert/data_source_service.go
@@ -22,6 +22,10 @@ func dataSourceService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"alias": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -57,6 +61,7 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any
 
 		d.SetId(strconv.FormatInt(found.ID, 10))
 		d.Set("name", found.Name)
+		d.Set("alias", found.Alias)
 		d.Set("status", found.Status)
 
 		return nil

--- a/ilert/resource_alert_action.go
+++ b/ilert/resource_alert_action.go
@@ -1340,11 +1340,12 @@ func transformAlertActionResource(alertAction *ilert.AlertActionOutput, d *schem
 			},
 		})
 	case ilert.ConnectorTypes.Autotask:
+		queueID, _ := strconv.Atoi(alertAction.Params.QueueID)
 		d.Set("autotask", []any{
 			map[string]any{
 				"company_id":      alertAction.Params.CompanyID,
 				"issue_type":      alertAction.Params.IssueType,
-				"queue_id":        alertAction.Params.QueueID,
+				"queue_id":        queueID,
 				"ticket_category": alertAction.Params.TicketCategory,
 				"ticket_type":     alertAction.Params.TicketType,
 				"note_type":       alertAction.Params.NoteType,

--- a/ilert/resource_alert_action.go
+++ b/ilert/resource_alert_action.go
@@ -1340,13 +1340,9 @@ func transformAlertActionResource(alertAction *ilert.AlertActionOutput, d *schem
 			},
 		})
 	case ilert.ConnectorTypes.Autotask:
-		companyID := ""
-		if alertAction.Params.CompanyID != 0 {
-			companyID = strconv.FormatInt(alertAction.Params.CompanyID, 10)
-		}
 		d.Set("autotask", []any{
 			map[string]any{
-				"company_id":      companyID,
+				"company_id":      alertAction.Params.CompanyID,
 				"issue_type":      alertAction.Params.IssueType,
 				"queue_id":        int(alertAction.Params.QueueID),
 				"ticket_category": alertAction.Params.TicketCategory,

--- a/ilert/resource_alert_action.go
+++ b/ilert/resource_alert_action.go
@@ -118,6 +118,30 @@ func resourceAlertAction() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"close_code": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"assignment_group": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"owner_group": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"service": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"service_offering": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"contact_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -302,6 +326,18 @@ func resourceAlertAction() *schema.Resource {
 							Optional: true,
 						},
 						"ticket_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"note_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"note_publish": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"status": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -690,10 +726,16 @@ func buildAlertAction(d *schema.ResourceData) (*ilert.AlertAction, error) {
 		if len(vL) > 0 {
 			v := vL[0].(map[string]any)
 			alertAction.Params = &ilert.AlertActionParamsServiceNow{
-				CallerID:     v["caller_id"].(string),
-				Impact:       v["impact"].(string),
-				Urgency:      v["urgency"].(string),
-				BodyTemplate: v["body_template"].(string),
+				CallerID:        v["caller_id"].(string),
+				Impact:          v["impact"].(string),
+				Urgency:         v["urgency"].(string),
+				BodyTemplate:    v["body_template"].(string),
+				CloseCode:       v["close_code"].(string),
+				AssignmentGroup: v["assignment_group"].(string),
+				OwnerGroup:      v["owner_group"].(string),
+				Service:         v["service"].(string),
+				ServiceOffering: v["service_offering"].(string),
+				ContactType:     v["contact_type"].(string),
 			}
 		}
 	}
@@ -808,6 +850,9 @@ func buildAlertAction(d *schema.ResourceData) (*ilert.AlertAction, error) {
 				QueueID:        int64(v["queue_id"].(int)),
 				TicketCategory: v["ticket_category"].(string),
 				TicketType:     v["ticket_type"].(string),
+				NoteType:       v["note_type"].(string),
+				NotePublish:    v["note_publish"].(string),
+				Status:         v["status"].(string),
 			}
 		}
 	}
@@ -1237,10 +1282,16 @@ func transformAlertActionResource(alertAction *ilert.AlertActionOutput, d *schem
 	case ilert.ConnectorTypes.ServiceNow:
 		d.Set("servicenow", []any{
 			map[string]any{
-				"caller_id":     alertAction.Params.CallerID,
-				"impact":        alertAction.Params.Impact,
-				"urgency":       alertAction.Params.Urgency,
-				"body_template": alertAction.Params.BodyTemplate,
+				"caller_id":        alertAction.Params.CallerID,
+				"impact":           alertAction.Params.Impact,
+				"urgency":          alertAction.Params.Urgency,
+				"body_template":    alertAction.Params.BodyTemplate,
+				"close_code":       alertAction.Params.CloseCode,
+				"assignment_group": alertAction.Params.AssignmentGroup,
+				"owner_group":      alertAction.Params.OwnerGroup,
+				"service":          alertAction.Params.Service,
+				"service_offering": alertAction.Params.ServiceOffering,
+				"contact_type":     alertAction.Params.ContactType,
 			},
 		})
 	case ilert.ConnectorTypes.Slack:
@@ -1296,6 +1347,9 @@ func transformAlertActionResource(alertAction *ilert.AlertActionOutput, d *schem
 				"queue_id":        alertAction.Params.QueueID,
 				"ticket_category": alertAction.Params.TicketCategory,
 				"ticket_type":     alertAction.Params.TicketType,
+				"note_type":       alertAction.Params.NoteType,
+				"note_publish":    alertAction.Params.NotePublish,
+				"status":          alertAction.Params.Status,
 			},
 		})
 	case ilert.ConnectorTypes.Zammad:

--- a/ilert/resource_alert_action.go
+++ b/ilert/resource_alert_action.go
@@ -1340,12 +1340,15 @@ func transformAlertActionResource(alertAction *ilert.AlertActionOutput, d *schem
 			},
 		})
 	case ilert.ConnectorTypes.Autotask:
-		queueID, _ := strconv.Atoi(alertAction.Params.QueueID)
+		companyID := ""
+		if alertAction.Params.CompanyID != 0 {
+			companyID = strconv.FormatInt(alertAction.Params.CompanyID, 10)
+		}
 		d.Set("autotask", []any{
 			map[string]any{
-				"company_id":      alertAction.Params.CompanyID,
+				"company_id":      companyID,
 				"issue_type":      alertAction.Params.IssueType,
-				"queue_id":        queueID,
+				"queue_id":        int(alertAction.Params.QueueID),
 				"ticket_category": alertAction.Params.TicketCategory,
 				"ticket_type":     alertAction.Params.TicketType,
 				"note_type":       alertAction.Params.NoteType,

--- a/ilert/resource_alert_action_test.go
+++ b/ilert/resource_alert_action_test.go
@@ -175,3 +175,59 @@ func alertSourceIDOrder(alertSources []any) []string {
 	}
 	return ids
 }
+
+func TestTransformAlertActionResource_AutotaskParams(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceAlertAction().Schema, map[string]any{
+		"name": "test-alert-action",
+		"connector": []any{
+			map[string]any{
+				"id":   "1",
+				"type": "autotask",
+			},
+		},
+		"trigger_mode": "ALL",
+		"alert_source": []any{
+			map[string]any{
+				"id": "123",
+			},
+		},
+	})
+	d.SetId("1")
+
+	alertAction := &ilertapi.AlertActionOutput{
+		Name:           "test-alert-action",
+		ConnectorType:  ilertapi.ConnectorTypes.Autotask,
+		AlertSourceIDs: []int64{},
+		Params: &ilertapi.AlertActionOutputParams{
+			CompanyID: 12345,
+			QueueID:   8,
+			NoteType:  "1",
+		},
+	}
+
+	// company_id (int64) is surfaced as a string, queue_id (int64) as an int.
+	if err := transformAlertActionResource(alertAction, d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	at := d.Get("autotask").([]any)[0].(map[string]any)
+	if at["company_id"] != "12345" {
+		t.Errorf("company_id = %v, want \"12345\"", at["company_id"])
+	}
+	if at["queue_id"] != 8 {
+		t.Errorf("queue_id = %v, want 8", at["queue_id"])
+	}
+	if at["note_type"] != "1" {
+		t.Errorf("note_type = %v, want \"1\"", at["note_type"])
+	}
+
+	// An unset company_id (0) must surface as an empty string, not "0", so it
+	// does not produce a spurious diff.
+	alertAction.Params.CompanyID = 0
+	if err := transformAlertActionResource(alertAction, d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	at = d.Get("autotask").([]any)[0].(map[string]any)
+	if at["company_id"] != "" {
+		t.Errorf("company_id = %v, want empty string when unset", at["company_id"])
+	}
+}

--- a/ilert/resource_alert_action_test.go
+++ b/ilert/resource_alert_action_test.go
@@ -199,13 +199,13 @@ func TestTransformAlertActionResource_AutotaskParams(t *testing.T) {
 		ConnectorType:  ilertapi.ConnectorTypes.Autotask,
 		AlertSourceIDs: []int64{},
 		Params: &ilertapi.AlertActionOutputParams{
-			CompanyID: 12345,
+			CompanyID: "12345",
 			QueueID:   8,
 			NoteType:  "1",
 		},
 	}
 
-	// company_id (int64) is surfaced as a string, queue_id (int64) as an int.
+	// company_id (string) passes through, queue_id (int64) surfaces as an int.
 	if err := transformAlertActionResource(alertAction, d); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -220,9 +220,18 @@ func TestTransformAlertActionResource_AutotaskParams(t *testing.T) {
 		t.Errorf("note_type = %v, want \"1\"", at["note_type"])
 	}
 
-	// An unset company_id (0) must surface as an empty string, not "0", so it
-	// does not produce a spurious diff.
-	alertAction.Params.CompanyID = 0
+	// A non-numeric company_id must round-trip untouched, and an unset one
+	// must stay an empty string.
+	alertAction.Params.CompanyID = "ACME-42"
+	if err := transformAlertActionResource(alertAction, d); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	at = d.Get("autotask").([]any)[0].(map[string]any)
+	if at["company_id"] != "ACME-42" {
+		t.Errorf("company_id = %v, want \"ACME-42\"", at["company_id"])
+	}
+
+	alertAction.Params.CompanyID = ""
 	if err := transformAlertActionResource(alertAction, d); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/ilert/resource_call_flow.go
+++ b/ilert/resource_call_flow.go
@@ -262,6 +262,10 @@ func resourceCallFlowNodeMetadata() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"disable_transcription": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"retries": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -558,6 +562,9 @@ func buildCallFlowNodeFromMap(rn map[string]any) (*ilert.CallFlowNode, error) {
 		}
 		if v, ok := mv["accept_alert_on_answer"].(bool); ok && v {
 			md.AcceptAlertOnAnswer = true
+		}
+		if v, ok := mv["disable_transcription"].(bool); ok && v {
+			md.DisableTranscription = true
 		}
 		if v, ok := mv["retries"].(int); ok && v != 0 {
 			md.Retries = int64(v)
@@ -1036,6 +1043,9 @@ func flattenCallFlowNode(node **ilert.CallFlowNode) ([]any, error) {
 			if v, ok := mdMap["acceptAlertOnAnswer"].(bool); ok && v {
 				md.AcceptAlertOnAnswer = true
 			}
+			if v, ok := mdMap["disableTranscription"].(bool); ok && v {
+				md.DisableTranscription = true
+			}
 			if v, ok := mdMap["retries"].(float64); ok && v != 0 {
 				md.Retries = int64(v)
 			}
@@ -1303,6 +1313,9 @@ func flattenCallFlowNodeMetadata(md *ilert.CallFlowNodeMetadata) ([]any, error) 
 	}
 	if md.AcceptAlertOnAnswer {
 		result["accept_alert_on_answer"] = true
+	}
+	if md.DisableTranscription {
+		result["disable_transcription"] = true
 	}
 	if md.Retries != 0 {
 		result["retries"] = int(md.Retries)

--- a/ilert/resource_call_flow_test.go
+++ b/ilert/resource_call_flow_test.go
@@ -114,3 +114,23 @@ func TestFlattenCallFlowNodeMetadata_AcceptAlertOnAnswer(t *testing.T) {
 		t.Error("expected accept_alert_on_answer to be absent from state when false")
 	}
 }
+
+func TestFlattenCallFlowNodeMetadata_DisableTranscription(t *testing.T) {
+	// true is surfaced into state.
+	result, err := flattenCallFlowNodeMetadata(&ilert.CallFlowNodeMetadata{DisableTranscription: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v := result[0].(map[string]any)["disable_transcription"]; v != true {
+		t.Errorf("expected disable_transcription = true in state, got %v", v)
+	}
+
+	// false is omitted (the backend default), so the key must be absent.
+	result, err = flattenCallFlowNodeMetadata(&ilert.CallFlowNodeMetadata{DisableTranscription: false})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := result[0].(map[string]any)["disable_transcription"]; ok {
+		t.Error("expected disable_transcription to be absent from state when false")
+	}
+}

--- a/ilert/resource_connection.go
+++ b/ilert/resource_connection.go
@@ -1225,11 +1225,12 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, m any) 
 			},
 		})
 	case ilert.ConnectorTypes.Autotask:
+		queueID, _ := strconv.Atoi(result.Connection.Params.QueueID)
 		d.Set("autotask", []any{
 			map[string]any{
 				"company_id":      result.Connection.Params.CompanyID,
 				"issue_type":      result.Connection.Params.IssueType,
-				"queue_id":        result.Connection.Params.QueueID,
+				"queue_id":        queueID,
 				"ticket_category": result.Connection.Params.TicketCategory,
 				"ticket_type":     result.Connection.Params.TicketType,
 			},

--- a/ilert/resource_connection.go
+++ b/ilert/resource_connection.go
@@ -1225,12 +1225,15 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, m any) 
 			},
 		})
 	case ilert.ConnectorTypes.Autotask:
-		queueID, _ := strconv.Atoi(result.Connection.Params.QueueID)
+		companyID := ""
+		if result.Connection.Params.CompanyID != 0 {
+			companyID = strconv.FormatInt(result.Connection.Params.CompanyID, 10)
+		}
 		d.Set("autotask", []any{
 			map[string]any{
-				"company_id":      result.Connection.Params.CompanyID,
+				"company_id":      companyID,
 				"issue_type":      result.Connection.Params.IssueType,
-				"queue_id":        queueID,
+				"queue_id":        int(result.Connection.Params.QueueID),
 				"ticket_category": result.Connection.Params.TicketCategory,
 				"ticket_type":     result.Connection.Params.TicketType,
 			},

--- a/ilert/resource_connection.go
+++ b/ilert/resource_connection.go
@@ -1225,13 +1225,9 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, m any) 
 			},
 		})
 	case ilert.ConnectorTypes.Autotask:
-		companyID := ""
-		if result.Connection.Params.CompanyID != 0 {
-			companyID = strconv.FormatInt(result.Connection.Params.CompanyID, 10)
-		}
 		d.Set("autotask", []any{
 			map[string]any{
-				"company_id":      companyID,
+				"company_id":      result.Connection.Params.CompanyID,
 				"issue_type":      result.Connection.Params.IssueType,
 				"queue_id":        int(result.Connection.Params.QueueID),
 				"ticket_category": result.Connection.Params.TicketCategory,

--- a/ilert/resource_service.go
+++ b/ilert/resource_service.go
@@ -22,6 +22,10 @@ func resourceService() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 255),
 			},
+			"alias": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"status": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -83,6 +87,10 @@ func buildService(d *schema.ResourceData) (*ilert.Service, error) {
 
 	service := &ilert.Service{
 		Name: name,
+	}
+
+	if val, ok := d.GetOk("alias"); ok {
+		service.Alias = val.(string)
 	}
 
 	if val, ok := d.GetOk("status"); ok {
@@ -308,6 +316,7 @@ func resourceServiceExists(d *schema.ResourceData, m any) (bool, error) {
 
 func transformServiceResource(service *ilert.Service, d *schema.ResourceData) error {
 	d.Set("name", service.Name)
+	d.Set("alias", service.Alias)
 	d.Set("status", service.Status)
 	d.Set("description", service.Description)
 	d.Set("one_open_incident_only", service.OneOpenIncidentOnly)

--- a/ilert/resource_service.go
+++ b/ilert/resource_service.go
@@ -25,6 +25,7 @@ func resourceService() *schema.Resource {
 			"alias": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"status": {
 				Type:         schema.TypeString,

--- a/ilert/resource_user.go
+++ b/ilert/resource_user.go
@@ -69,6 +69,7 @@ func resourceUser() *schema.Resource {
 					"RESPONDER",
 					"STAKEHOLDER",
 					"GUEST",
+					"VIEWER",
 				}, false),
 			},
 			"shift_color": {

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 
 - `id` - The ID of the found service.
 - `name` - The name of the found service.
+- `alias` - The alias of the found service.
 - `status` - The status of the found service.
 
 [1]: https://api.ilert.com/api-docs/#tag/Services

--- a/website/docs/r/alert_action.html.markdown
+++ b/website/docs/r/alert_action.html.markdown
@@ -120,6 +120,12 @@ The following arguments are supported:
 - `impact` - (Optional) The ServiceNow impact.
 - `urgency` - (Optional) The ServiceNow urgency.
 - `body_template` - (Optional) The custom template body.
+- `close_code` - (Optional) The ServiceNow close code.
+- `assignment_group` - (Optional) The ServiceNow assignment group.
+- `owner_group` - (Optional) The ServiceNow owner group.
+- `service` - (Optional) The ServiceNow service.
+- `service_offering` - (Optional) The ServiceNow service offering.
+- `contact_type` - (Optional) The ServiceNow contact type.
 
 #### Slack Arguments
 
@@ -180,6 +186,9 @@ The following arguments are supported:
 - `issue_type` - (Optional) The Autotask Issue Type.
 - `ticket_category` - (Optional) The Autotask Ticket Category.
 - `ticket_type` - (Optional) The Autotask Ticket Type.
+- `note_type` - (Optional) The Autotask note type.
+- `note_publish` - (Optional) The Autotask note publish.
+- `status` - (Optional) The Autotask ticket status.
 
 #### Zammad Arguments
 

--- a/website/docs/r/call_flow.html.markdown
+++ b/website/docs/r/call_flow.html.markdown
@@ -72,6 +72,7 @@ The following arguments are supported:
 - `call_style` - (Optional) Required with node type: `ROUTE_CALL`. Allowed values: `ORDERED`, `RANDOM`, `PARALLEL`.
 - `alert_source_id` - (Optional) Used by node type: `CREATE_ALERT`.
 - `accept_alert_on_answer` - (Optional) Used by node type: `CREATE_ALERT`. When enabled, the created alert is accepted automatically once the call is answered.
+- `disable_transcription` - (Optional) Used by node type: `VOICEMAIL`. When enabled, the voicemail recording is not transcribed.
 - `retries` - (Optional) Used by node types: `IVR_MENU`, `PIN_CODE`, `ROUTE_CALL`.
 - `call_timeout_sec` - (Optional) Used by node type: `ROUTE_CALL`.
 - `blacklist` - (Optional) Used by node type: `BLOCK_NUMBERS`.

--- a/website/docs/r/service.html.markdown
+++ b/website/docs/r/service.html.markdown
@@ -25,6 +25,7 @@ resource "ilert_service" "example" {
 The following arguments are supported:
 
 - `name` - (Required) The name of the service.
+- `alias` - (Optional) The alias of the service.
 - `status` - (Optional) The status of the service. Allowed values are `OPERATIONAL`, `UNDER_MAINTENANCE`, `DEGRADED`, `PARTIAL_OUTAGE`, `MAJOR_OUTAGE`.
 - `description` - (Optional) The description of the service.
 - `one_open_incident_only` - (Optional) Indicates whether or not only one incident should be opened. Default: `false`

--- a/website/docs/r/team.html.markdown
+++ b/website/docs/r/team.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 #### Member Arguments
 
 - `user` - (Required) The user id of the team member.
-- `role` - (Optional) The role of the team member. Allowed values are `ADMIN`, `USER`, `RESPONDER` and `STAKEHOLDER`. Default: `RESPONDER`.
+- `role` - (Optional) The role of the team member. Allowed values are `ADMIN`, `USER`, `RESPONDER`, `STAKEHOLDER` and `VIEWER`. Default: `RESPONDER`.
 
 ## Attributes Reference
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 - `department` - (Optional) The user's department.
 - `language` - (Optional) The user's language. Allowed values are `en`, `de`.
 - `region` - (Optional) The user's region e.g. `EN`, `DE`.
-- `role` - (Optional) The user's role. Allowed values are `ADMIN`, `USER`, `RESPONDER` or `STAKEHOLDER`. Default: `USER`
+- `role` - (Optional) The user's role. Allowed values are `ADMIN`, `USER`, `RESPONDER`, `STAKEHOLDER`, `GUEST` or `VIEWER`. Default: `USER`
 - `shift_color` - (Optional) The hex code for the user's shift color.
 - `send_no_invitation` - (Optional) Boolean whether an invitation email notification is sent to the user. Defaults to `false`.
 


### PR DESCRIPTION
- add `close_code`, `assignment_group`, `owner_group`, `service`, `service_offering` and `contact_type` to the alert action `servicenow` params
- add `note_type`, `note_publish` and `status` to the alert action `autotask` params
- add `alias` to the service resource and data source (computed, so aliases set outside Terraform are preserved)
- add `disable_transcription` to call flow `VOICEMAIL` node metadata
- add `VIEWER` to the user resource role and the team member role
- fix reading autotask alert actions and connections whose `queue_id`/`company_id` the API returns as strings