### PR TITLE
Fix/alert source email update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 24.07.2026, Version 2.23.1
+## 27.07.2026, Version 2.23.1
 
 - fix email address not updating on `EMAIL`/`EMAIL2` alert sources; the computed `integration_key` (holding the previous value from state) was overwriting the new value from the `email` field on update [#148](https://github.com/iLert/terraform-provider-ilert/pull/148)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 24.07.2026, Version 2.23.1
+
+- fix email address not updating on `EMAIL`/`EMAIL2` alert sources; the computed `integration_key` (holding the previous value from state) was overwriting the new value from the `email` field on update [#148](https://github.com/iLert/terraform-provider-ilert/pull/148)
+
 ## 23.07.2026, Version 2.23.0
 
 - add documented `servicenow` (`close_code`, `assignment_group`, `owner_group`, `service`, `service_offering`, `contact_type`) and `autotask` (`note_type`, `note_publish`, `status`) alert action params, service `alias` and call flow `VOICEMAIL` `disable_transcription` [#146](https://github.com/iLert/terraform-provider-ilert/pull/146)

--- a/ilert/resource_alert_source.go
+++ b/ilert/resource_alert_source.go
@@ -742,7 +742,11 @@ func buildAlertSource(d *schema.ResourceData) (*ilert.AlertSource, error) {
 		}
 		alertSource.AlertCreation = alertCreation
 	}
-	if val, ok := d.GetOk("integration_key"); ok {
+	// EMAIL/EMAIL2 sources carry their address in integration_key, which is set
+	// from the "email" field above. integration_key is computed, so on update it
+	// still holds the previous value from state; letting it run here would
+	// overwrite the new email and silently no-op the update.
+	if val, ok := d.GetOk("integration_key"); ok && integrationType != "EMAIL" && integrationType != "EMAIL2" {
 		integrationKey := val.(string)
 		alertSource.IntegrationKey = integrationKey
 	}

--- a/ilert/resource_alert_source_test.go
+++ b/ilert/resource_alert_source_test.go
@@ -292,3 +292,50 @@ func TestBuildAlertSource_ServicesAndServicesTemplate(t *testing.T) {
 		t.Fatalf("expected auto_create_services to be true")
 	}
 }
+
+// Regression for #147: on update the computed integration_key still holds the
+// previous address from state. It must not overwrite the new value coming from
+// the "email" field, otherwise the email update silently no-ops.
+func TestBuildAlertSource_EmailUpdateNotClobberedByStaleIntegrationKey(t *testing.T) {
+	for _, integrationType := range []string{"EMAIL", "EMAIL2"} {
+		t.Run(integrationType, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t, resourceAlertSource().Schema, map[string]any{
+				"name":              "test-alert-source",
+				"integration_type":  integrationType,
+				"escalation_policy": "1",
+				"email":             "new-address",
+				// simulates the computed value carried over from prior state
+				"integration_key": "old-address@example.ilertnotify.dev",
+			})
+
+			alertSource, err := buildAlertSource(d)
+			if err != nil {
+				t.Fatalf("unexpected error building alert source: %v", err)
+			}
+
+			if alertSource.IntegrationKey != "new-address" {
+				t.Fatalf("expected integration key %q, got %q", "new-address", alertSource.IntegrationKey)
+			}
+		})
+	}
+}
+
+// Non-email sources must still honor integration_key (its address is server-computed
+// and sent back on update); the #147 guard only skips EMAIL/EMAIL2.
+func TestBuildAlertSource_NonEmailKeepsIntegrationKey(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceAlertSource().Schema, map[string]any{
+		"name":              "test-alert-source",
+		"integration_type":  "API",
+		"escalation_policy": "1",
+		"integration_key":   "server-generated-key",
+	})
+
+	alertSource, err := buildAlertSource(d)
+	if err != nil {
+		t.Fatalf("unexpected error building alert source: %v", err)
+	}
+
+	if alertSource.IntegrationKey != "server-generated-key" {
+		t.Fatalf("expected integration key %q, got %q", "server-generated-key", alertSource.IntegrationKey)
+	}
+}


### PR DESCRIPTION
- fix email address not updating on `EMAIL` / `EMAIL2` alert sources: the computed `integration_key` (holding the previous value from state) was overwriting the new value built from the `email` field on update, making the change a silent no-op