### PR TITLE
fix: mark deployment pipeline creds as sensitive

### DIFF
--- a/ilert/resource_deployment_pipeline.go
+++ b/ilert/resource_deployment_pipeline.go
@@ -29,8 +29,9 @@ func resourceDeploymentPipeline() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(ilert.DeploymentPipelineIntegrationTypeAll, false),
 			},
 			"integration_key": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"team": {
 				Type:     schema.TypeList,
@@ -59,8 +60,9 @@ func resourceDeploymentPipeline() *schema.Resource {
 				Computed: true,
 			},
 			"integration_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"github": {
 				Type:     schema.TypeList,

--- a/ilert/resource_deployment_pipeline_test.go
+++ b/ilert/resource_deployment_pipeline_test.go
@@ -1,0 +1,23 @@
+package ilert
+
+import "testing"
+
+func TestResourceDeploymentPipeline_CredentialsAreSensitive(t *testing.T) {
+	resourceSchema := resourceDeploymentPipeline().Schema
+
+	for _, attribute := range []string{"integration_key", "integration_url"} {
+		t.Run(attribute, func(t *testing.T) {
+			attributeSchema, ok := resourceSchema[attribute]
+			if !ok {
+				t.Fatalf("schema is missing %q", attribute)
+			}
+
+			if !attributeSchema.Computed {
+				t.Errorf("expected %q to be computed", attribute)
+			}
+			if !attributeSchema.Sensitive {
+				t.Errorf("expected %q to be sensitive", attribute)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Redact integration_key and integration_url from human readable output to avoid exposing sensitive info.