### PR TITLE
fix(team): sort members not in state

### DIFF
--- a/ilert/resource_team.go
+++ b/ilert/resource_team.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
 	"strconv"
 	"time"
 
@@ -341,7 +342,15 @@ func flattenMembersListSorted(list []ilert.TeamMember, d *schema.ResourceData) (
 		}
 	}
 
+	unmatchedServerMembers := make([]ilert.TeamMember, 0, len(serverMembersMap))
 	for _, serverMember := range serverMembersMap {
+		unmatchedServerMembers = append(unmatchedServerMembers, serverMember)
+	}
+	sort.Slice(unmatchedServerMembers, func(i, j int) bool {
+		return unmatchedServerMembers[i].User.ID < unmatchedServerMembers[j].User.ID
+	})
+
+	for _, serverMember := range unmatchedServerMembers {
 		result := make(map[string]any)
 		result["role"] = serverMember.Role
 		if serverMember.User.ID > 0 {

--- a/ilert/resource_team.go
+++ b/ilert/resource_team.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"sort"
 	"strconv"
 	"time"
 
@@ -30,7 +29,7 @@ func resourceTeam() *schema.Resource {
 				ValidateFunc: validation.StringInSlice(ilert.TeamVisibilityAll, false),
 			},
 			"member": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -76,7 +75,7 @@ func buildTeam(d *schema.ResourceData) (*ilert.Team, error) {
 
 	members := make([]ilert.TeamMember, 0)
 	if val, ok := d.GetOk("member"); ok {
-		vL := val.([]any)
+		vL := val.(*schema.Set).List()
 		for _, m := range vL {
 			v := m.(map[string]any)
 			ep := ilert.TeamMember{
@@ -290,10 +289,7 @@ func transformTeamResource(team *ilert.Team, d *schema.ResourceData) error {
 	d.Set("name", team.Name)
 	d.Set("visibility", team.Visibility)
 
-	members, err := flattenMembersListSorted(team.Members, d)
-	if err != nil {
-		return fmt.Errorf("[ERROR] Error flattening members: %s", err.Error())
-	}
+	members := flattenMembersList(team.Members)
 	if err := d.Set("member", members); err != nil {
 		return fmt.Errorf("[ERROR] Error setting members: %s", err.Error())
 	}
@@ -301,56 +297,13 @@ func transformTeamResource(team *ilert.Team, d *schema.ResourceData) error {
 	return nil
 }
 
-func flattenMembersListSorted(list []ilert.TeamMember, d *schema.ResourceData) ([]any, error) {
+func flattenMembersList(list []ilert.TeamMember) []any {
 	if list == nil {
-		return make([]any, 0), nil
+		return make([]any, 0)
 	}
 
-	configMembers := d.Get("member")
-	if configMembers == nil {
-		if d.Id() != "" {
-			return make([]any, 0), nil
-		}
-		configMembers = make([]any, 0)
-	}
-
-	configMembersList, ok := configMembers.([]any)
-	if !ok {
-		return make([]any, 0), nil
-	}
-
-	serverMembersMap := make(map[string]ilert.TeamMember)
-	for _, member := range list {
-		if member.User.ID > 0 {
-			userID := strconv.FormatInt(member.User.ID, 10)
-			serverMembersMap[userID] = member
-		}
-	}
-
-	results := make([]any, 0)
-	for _, configMember := range configMembersList {
-		if configMemberMap, ok := configMember.(map[string]any); ok {
-			if userID, ok := configMemberMap["user"].(string); ok {
-				if serverMember, exists := serverMembersMap[userID]; exists {
-					result := make(map[string]any)
-					result["role"] = serverMember.Role
-					result["user"] = userID
-					results = append(results, result)
-					delete(serverMembersMap, userID)
-				}
-			}
-		}
-	}
-
-	unmatchedServerMembers := make([]ilert.TeamMember, 0, len(serverMembersMap))
-	for _, serverMember := range serverMembersMap {
-		unmatchedServerMembers = append(unmatchedServerMembers, serverMember)
-	}
-	sort.Slice(unmatchedServerMembers, func(i, j int) bool {
-		return unmatchedServerMembers[i].User.ID < unmatchedServerMembers[j].User.ID
-	})
-
-	for _, serverMember := range unmatchedServerMembers {
+	results := make([]any, 0, len(list))
+	for _, serverMember := range list {
 		result := make(map[string]any)
 		result["role"] = serverMember.Role
 		if serverMember.User.ID > 0 {
@@ -359,5 +312,5 @@ func flattenMembersListSorted(list []ilert.TeamMember, d *schema.ResourceData) (
 		results = append(results, result)
 	}
 
-	return results, nil
+	return results
 }

--- a/ilert/resource_team_test.go
+++ b/ilert/resource_team_test.go
@@ -1,7 +1,6 @@
 package ilert
 
 import (
-	"reflect"
 	"slices"
 	"testing"
 
@@ -36,12 +35,12 @@ func TestFlattenMembersListSorted_UsesConfigOrder(t *testing.T) {
 
 	wantOrder := []string{"200", "100"}
 	gotOrder := teamMemberUserOrder(got)
-	if !reflect.DeepEqual(gotOrder, wantOrder) {
+	if !slices.Equal(gotOrder, wantOrder) {
 		t.Fatalf("expected user order %v, got %v", wantOrder, gotOrder)
 	}
 }
 
-func TestFlattenMembersListSorted_AppendsUnmatchedServerMember(t *testing.T) {
+func TestFlattenMembersListSorted_AppendsSortedUnmatchedServerMembers(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceTeam().Schema, map[string]any{
 		"name": "test-team",
 		"member": []any{
@@ -55,6 +54,7 @@ func TestFlattenMembersListSorted_AppendsUnmatchedServerMember(t *testing.T) {
 	serverMembers := []ilert.TeamMember{
 		newTeamMember(100, ilert.TeamMemberRoles.User),
 		newTeamMember(200, ilert.TeamMemberRoles.Responder),
+		newTeamMember(10, ilert.TeamMemberRoles.User),
 	}
 
 	got, err := flattenMembersListSorted(serverMembers, d)
@@ -63,14 +63,15 @@ func TestFlattenMembersListSorted_AppendsUnmatchedServerMember(t *testing.T) {
 	}
 
 	gotOrder := teamMemberUserOrder(got)
-	if len(gotOrder) != 2 {
-		t.Fatalf("expected 2 users, got %d (%v)", len(gotOrder), gotOrder)
+	if len(gotOrder) != 3 {
+		t.Fatalf("expected 3 users, got %d (%v)", len(gotOrder), gotOrder)
 	}
 	if gotOrder[0] != "200" {
 		t.Fatalf("expected configured user first, got %v", gotOrder)
 	}
-	if !slices.Contains(gotOrder, "100") {
-		t.Fatalf("expected unmatched server user 100 to be preserved, got %v", gotOrder)
+	wantOrder := []string{"200", "10", "100"}
+	if !slices.Equal(gotOrder, wantOrder) {
+		t.Fatalf("expected user order %v, got %v", wantOrder, gotOrder)
 	}
 }
 

--- a/ilert/resource_team_test.go
+++ b/ilert/resource_team_test.go
@@ -1,77 +1,42 @@
 package ilert
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/iLert/ilert-go/v3"
 )
 
-func TestFlattenMembersListSorted_UsesConfigOrder(t *testing.T) {
-	d := schema.TestResourceDataRaw(t, resourceTeam().Schema, map[string]any{
-		"name": "test-team",
-		"member": []any{
-			map[string]any{
-				"user": "200",
-				"role": ilert.TeamMemberRoles.Responder,
-			},
-			map[string]any{
-				"user": "100",
-				"role": ilert.TeamMemberRoles.User,
-			},
+func TestTeamMembersRoundTrip(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceTeam().Schema, map[string]any{})
+	team := &ilert.Team{
+		Name:       "test-team",
+		Visibility: ilert.TeamVisibility.Public,
+		Members: []ilert.TeamMember{
+			newTeamMember(200, ilert.TeamMemberRoles.Responder),
+			newTeamMember(100, ilert.TeamMemberRoles.User),
 		},
-	})
-
-	serverMembers := []ilert.TeamMember{
-		newTeamMember(100, ilert.TeamMemberRoles.User),
-		newTeamMember(200, ilert.TeamMemberRoles.Responder),
 	}
 
-	got, err := flattenMembersListSorted(serverMembers, d)
+	if err := transformTeamResource(team, d); err != nil {
+		t.Fatalf("unexpected error transforming team: %v", err)
+	}
+	got, err := buildTeam(d)
 	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
+		t.Fatalf("unexpected error building team: %v", err)
 	}
 
-	wantOrder := []string{"200", "100"}
-	gotOrder := teamMemberUserOrder(got)
-	if !slices.Equal(gotOrder, wantOrder) {
-		t.Fatalf("expected user order %v, got %v", wantOrder, gotOrder)
+	wantMembers := map[int64]string{
+		100: ilert.TeamMemberRoles.User,
+		200: ilert.TeamMemberRoles.Responder,
 	}
-}
-
-func TestFlattenMembersListSorted_AppendsSortedUnmatchedServerMembers(t *testing.T) {
-	d := schema.TestResourceDataRaw(t, resourceTeam().Schema, map[string]any{
-		"name": "test-team",
-		"member": []any{
-			map[string]any{
-				"user": "200",
-				"role": ilert.TeamMemberRoles.Responder,
-			},
-		},
-	})
-
-	serverMembers := []ilert.TeamMember{
-		newTeamMember(100, ilert.TeamMemberRoles.User),
-		newTeamMember(200, ilert.TeamMemberRoles.Responder),
-		newTeamMember(10, ilert.TeamMemberRoles.User),
+	if len(got.Members) != len(wantMembers) {
+		t.Fatalf("expected %d members, got %d", len(wantMembers), len(got.Members))
 	}
-
-	got, err := flattenMembersListSorted(serverMembers, d)
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-
-	gotOrder := teamMemberUserOrder(got)
-	if len(gotOrder) != 3 {
-		t.Fatalf("expected 3 users, got %d (%v)", len(gotOrder), gotOrder)
-	}
-	if gotOrder[0] != "200" {
-		t.Fatalf("expected configured user first, got %v", gotOrder)
-	}
-	wantOrder := []string{"200", "10", "100"}
-	if !slices.Equal(gotOrder, wantOrder) {
-		t.Fatalf("expected user order %v, got %v", wantOrder, gotOrder)
+	for _, member := range got.Members {
+		if wantRole, ok := wantMembers[member.User.ID]; !ok || member.Role != wantRole {
+			t.Fatalf("unexpected member %d with role %q", member.User.ID, member.Role)
+		}
 	}
 }
 
@@ -82,19 +47,4 @@ func newTeamMember(userID int64, role string) ilert.TeamMember {
 		},
 		Role: role,
 	}
-}
-
-func teamMemberUserOrder(members []any) []string {
-	order := make([]string, 0, len(members))
-	for _, member := range members {
-		memberMap, ok := member.(map[string]any)
-		if !ok {
-			continue
-		}
-		user, ok := memberMap["user"].(string)
-		if ok {
-			order = append(order, user)
-		}
-	}
-	return order
 }


### PR DESCRIPTION
Sort members missing from state by user ID to prevent unstable ordering during import and refresh.

Keep existing list schema to preserve compatibility. Using a set would make HCL order irrelevant, but requires a separate migration.