### PR TITLE
Fix/alert source teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 30.07.2026, Version 2.23.2
+
+- fix a permanent diff on alert source `team` blocks whose declared order differs from the order the API returns them in: the API sorts teams by id, so the ordered `TypeList` produced a plan that swapped ids back and forth on every run and never converged, even directly after a successful apply. `team` is now a `TypeSet`, and the read binds each configured team `name` to its own team id instead of zipping config and API order by position [#150](https://github.com/iLert/terraform-provider-ilert/issues/150)
+- fix removing every `team` block from an alert source silently doing nothing: the teams were dropped from the Terraform state while remaining assigned on the server. The empty list was omitted from the update payload entirely, and the API only clears teams on an explicit empty array. Removing a subset was unaffected [#151](https://github.com/iLert/terraform-provider-ilert/issues/151)
+
 ## 27.07.2026, Version 2.23.1
 
 - fix email address not updating on `EMAIL`/`EMAIL2` alert sources; the computed `integration_key` (holding the previous value from state) was overwriting the new value from the `email` field on update [#148](https://github.com/iLert/terraform-provider-ilert/pull/148)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
-## 30.07.2026, Version 2.23.2
+## 03.08.2026, Version 2.24.0
 
+- **Upgrade note:** `integration_key` and `integration_url` are now marked sensitive on the heartbeat monitor and deployment pipeline, matching the alert source. An `output` referencing one of them fails with `Output refers to sensitive values` until it is annotated with `sensitive = true`. This redacts console and log output only, the values are still stored in plain text in the Terraform state.
+- **Upgrade note:** the alert source `team` block and the team `member` block are now sets, so positional access such as `ilert_team.example.member[0].role` fails with `Cannot index a set value`. Use a `for` expression, `one()` or `tolist()` instead. Existing state needs no migration and `dynamic` blocks are unaffected.
+- **Upgrade note:** an alert source's teams are managed by Terraform only once a `team` block is declared, and removing every block now clears them on the server. Alert sources left inconsistent by the bug fixed below, with the teams dropped from state but still assigned on the server, are not corrected automatically: declare the blocks again, apply, then delete them.
+- mark `integration_key` and `integration_url` on the deployment pipeline resource as sensitive, so they are redacted from plan, apply and `terraform show` output [#152](https://github.com/iLert/terraform-provider-ilert/pull/152)
+- mark `integration_key` and `integration_url` on the heartbeat monitor resource and data source as sensitive [#153](https://github.com/iLert/terraform-provider-ilert/pull/153)
+- fix unstable ordering of team `member` blocks on import and refresh; `member` is now a `TypeSet`, so the order the blocks are declared in no longer matters [#154](https://github.com/iLert/terraform-provider-ilert/pull/154)
 - fix a permanent diff on alert source `team` blocks whose declared order differs from the order the API returns them in: the API sorts teams by id, so the ordered `TypeList` produced a plan that swapped ids back and forth on every run and never converged, even directly after a successful apply. `team` is now a `TypeSet`, and the read binds each configured team `name` to its own team id instead of zipping config and API order by position [#150](https://github.com/iLert/terraform-provider-ilert/issues/150)
 - fix removing every `team` block from an alert source silently doing nothing: the teams were dropped from the Terraform state while remaining assigned on the server. The empty list was omitted from the update payload entirely, and the API only clears teams on an explicit empty array. Removing a subset was unaffected [#151](https://github.com/iLert/terraform-provider-ilert/issues/151)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
-	github.com/iLert/ilert-go/v3 v3.23.0
+	github.com/iLert/ilert-go/v3 v3.23.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/iLert/ilert-go/v3 v3.23.0 h1:tYJ5BePXjGtT8yT5AB5ePyycYGLaPMn1ynWxwBoMnHc=
-github.com/iLert/ilert-go/v3 v3.23.0/go.mod h1:xHJ8qdmthK4HExcQOd3V5JARed/EBKTdX86MqrJ1yJ0=
+github.com/iLert/ilert-go/v3 v3.23.1 h1:cpCVqTORSv9wAqowvaV5YC93nn2cVggM91E9AUzdUGs=
+github.com/iLert/ilert-go/v3 v3.23.1/go.mod h1:xHJ8qdmthK4HExcQOd3V5JARed/EBKTdX86MqrJ1yJ0=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/ilert/resource_alert_source.go
+++ b/ilert/resource_alert_source.go
@@ -159,7 +159,10 @@ func resourceAlertSource() *schema.Resource {
 				},
 			},
 			"team": {
-				Type:     schema.TypeList,
+				// TypeSet, not TypeList: the API returns teams sorted by id, so an
+				// ordered list produces a permanent diff whenever the config order
+				// differs from that.
+				Type:     schema.TypeSet,
 				Optional: true,
 				MinItems: 1,
 				Elem: &schema.Resource{
@@ -795,7 +798,7 @@ func buildAlertSource(d *schema.ResourceData) (*ilert.AlertSource, error) {
 		alertSource.Teams = tms
 	}
 	if val, ok := d.GetOk("team"); ok {
-		vL := val.([]any)
+		vL := val.(*schema.Set).List()
 		tms := make([]ilert.TeamShort, 0)
 		for _, m := range vL {
 			v := m.(map[string]any)
@@ -808,6 +811,10 @@ func buildAlertSource(d *schema.ResourceData) (*ilert.AlertSource, error) {
 			tms = append(tms, tm)
 		}
 		alertSource.Teams = tms
+	} else if _, usesDeprecatedTeams := d.GetOk("teams"); !usesDeprecatedTeams {
+		// All team blocks removed. The API only clears teams on an explicit empty
+		// array; an omitted or null field leaves them untouched.
+		alertSource.Teams = []ilert.TeamShort{}
 	}
 	if val, ok := d.GetOk("support_hours"); ok {
 		vL := val.([]any)
@@ -1492,24 +1499,27 @@ func transformAlertSourceResource(alertSource *ilert.AlertSource, d *schema.Reso
 
 	if val, ok := d.GetOk("team"); ok {
 		if val != nil {
-			vL := val.([]any)
+			// Match the config by team id, not by position: the API returns teams
+			// sorted by id, which need not match the order they were declared in.
+			requestedTeamNames := make(map[int64]bool)
+			for _, m := range val.(*schema.Set).List() {
+				v, ok := m.(map[string]any)
+				if !ok || v["name"] == nil {
+					continue
+				}
+				if vName, ok := v["name"].(string); ok && vName != "" {
+					requestedTeamNames[int64(v["id"].(int))] = true
+				}
+			}
+
 			teams := make([]any, 0)
-			for i, item := range alertSource.Teams {
+			for _, item := range alertSource.Teams {
 				team := make(map[string]any)
 				team["id"] = item.ID
 
-				var requestedTeamName string
-				if i < len(vL) && vL[i] != nil {
-					if v, ok := vL[i].(map[string]any); ok && v["name"] != nil {
-						if vName, ok := v["name"].(string); ok {
-							requestedTeamName = vName
-						}
-					}
-				}
-
 				// Means: if server response has a name set, and the user typed in a name too,
 				// only then team name is stored in the terraform state
-				if item.Name != "" && requestedTeamName != "" {
+				if item.Name != "" && requestedTeamNames[item.ID] {
 					team["name"] = item.Name
 				}
 				teams = append(teams, team)

--- a/ilert/resource_alert_source.go
+++ b/ilert/resource_alert_source.go
@@ -811,9 +811,12 @@ func buildAlertSource(d *schema.ResourceData) (*ilert.AlertSource, error) {
 			tms = append(tms, tm)
 		}
 		alertSource.Teams = tms
-	} else if _, usesDeprecatedTeams := d.GetOk("teams"); !usesDeprecatedTeams {
+	} else if _, usesDeprecatedTeams := d.GetOk("teams"); !usesDeprecatedTeams && d.HasChange("team") {
 		// All team blocks removed. The API only clears teams on an explicit empty
-		// array; an omitted or null field leaves them untouched.
+		// array; an omitted or null field leaves them untouched. HasChange keeps
+		// this to alert sources whose teams were actually dropped from the config:
+		// without it every update on a config that never declared a team block
+		// would clear the teams assigned to it elsewhere.
 		alertSource.Teams = []ilert.TeamShort{}
 	}
 	if val, ok := d.GetOk("support_hours"); ok {

--- a/ilert/resource_alert_source_test.go
+++ b/ilert/resource_alert_source_test.go
@@ -1,6 +1,8 @@
 package ilert
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -35,9 +37,99 @@ func TestTransformAlertSourceResource_DoesNotPanicWhenAPIReturnsMoreTeamsThanSta
 		t.Fatalf("unexpected error transforming alert source: %v", err)
 	}
 
-	teams := d.Get("team").([]any)
+	teams := d.Get("team").(*schema.Set).List()
 	if len(teams) != 2 {
 		t.Fatalf("expected 2 teams in state, got %d", len(teams))
+	}
+}
+
+// Regression for #150: the API returns teams sorted by id, which need not match
+// the order they were declared in. The read must bind each configured name to its
+// own team id rather than zipping the two lists by position.
+func TestTransformAlertSourceResource_BindsTeamNamesByIDNotPosition(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceAlertSource().Schema, map[string]any{
+		"name":              "test-alert-source",
+		"integration_type":  "API",
+		"escalation_policy": "1",
+		// declared in the reverse of the order the API returns
+		"team": []any{
+			map[string]any{"id": 2, "name": "Team 2"},
+			map[string]any{"id": 1, "name": "Team 1"},
+		},
+	})
+
+	alertSource := &ilertapi.AlertSource{
+		Name:             "test-alert-source",
+		EscalationPolicy: &ilertapi.EscalationPolicy{ID: 1},
+		Teams: []ilertapi.TeamShort{
+			{ID: 1, Name: "Team 1"},
+			{ID: 2, Name: "Team 2"},
+		},
+	}
+
+	if err := transformAlertSourceResource(alertSource, d); err != nil {
+		t.Fatalf("unexpected error transforming alert source: %v", err)
+	}
+
+	got := make(map[int]string)
+	for _, item := range d.Get("team").(*schema.Set).List() {
+		v := item.(map[string]any)
+		got[v["id"].(int)] = v["name"].(string)
+	}
+
+	if got[1] != "Team 1" || got[2] != "Team 2" {
+		t.Fatalf("team names bound to the wrong ids: %v", got)
+	}
+}
+
+// Regression for #151: with every team block removed the API only clears teams on
+// an explicit empty array. An omitted or null "teams" field leaves them untouched,
+// so the built payload must carry a non-nil empty slice.
+func TestBuildAlertSource_RemovingAllTeamsSendsEmptyArray(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceAlertSource().Schema, map[string]any{
+		"name":              "test-alert-source",
+		"integration_type":  "API",
+		"escalation_policy": "1",
+	})
+
+	alertSource, err := buildAlertSource(d)
+	if err != nil {
+		t.Fatalf("unexpected error building alert source: %v", err)
+	}
+
+	if alertSource.Teams == nil {
+		t.Fatal("expected non-nil empty teams slice, got nil (marshals to null, which the API ignores)")
+	}
+	if len(alertSource.Teams) != 0 {
+		t.Fatalf("expected 0 teams, got %d", len(alertSource.Teams))
+	}
+
+	payload, err := json.Marshal(alertSource)
+	if err != nil {
+		t.Fatalf("unexpected error marshalling alert source: %v", err)
+	}
+	if !strings.Contains(string(payload), `"teams":[]`) {
+		t.Fatalf("expected payload to contain \"teams\":[], got %s", payload)
+	}
+}
+
+// The deprecated top-level "teams" field must keep working: the empty-array fallback
+// above must not clobber teams supplied through it.
+func TestBuildAlertSource_DeprecatedTeamsFieldNotClobbered(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourceAlertSource().Schema, map[string]any{
+		"name":              "test-alert-source",
+		"integration_type":  "API",
+		"escalation_policy": "1",
+		"teams":             []any{1, 2},
+	})
+
+	alertSource, err := buildAlertSource(d)
+	if err != nil {
+		t.Fatalf("unexpected error building alert source: %v", err)
+	}
+
+	if len(alertSource.Teams) != 2 {
+		t.Fatalf("expected 2 teams from the deprecated field, got %d", len(alertSource.Teams))
 	}
 }
 

--- a/ilert/resource_alert_source_test.go
+++ b/ilert/resource_alert_source_test.go
@@ -1,11 +1,13 @@
 package ilert
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	ilertapi "github.com/iLert/ilert-go/v3"
 )
 
@@ -82,15 +84,50 @@ func TestTransformAlertSourceResource_BindsTeamNamesByIDNotPosition(t *testing.T
 	}
 }
 
+// testResourceDataForUpdate builds the ResourceData an update sees: the prior
+// state diffed against the new configuration. TestResourceDataRaw has no prior
+// state, so it cannot express an attribute that was removed from the config.
+func testResourceDataForUpdate(t *testing.T, resource *schema.Resource, priorRaw, raw map[string]any) *schema.ResourceData {
+	t.Helper()
+
+	prior := schema.TestResourceDataRaw(t, resource.Schema, priorRaw)
+	prior.SetId("1")
+
+	state := prior.State()
+	resourceSchema := schema.InternalMap(resource.Schema)
+
+	diff, err := resourceSchema.Diff(context.Background(), state, terraform.NewResourceConfigRaw(raw), nil, nil, true)
+	if err != nil {
+		t.Fatalf("unexpected error diffing: %v", err)
+	}
+
+	d, err := resourceSchema.Data(state, diff)
+	if err != nil {
+		t.Fatalf("unexpected error building resource data: %v", err)
+	}
+
+	return d
+}
+
 // Regression for #151: with every team block removed the API only clears teams on
 // an explicit empty array. An omitted or null "teams" field leaves them untouched,
 // so the built payload must carry a non-nil empty slice.
 func TestBuildAlertSource_RemovingAllTeamsSendsEmptyArray(t *testing.T) {
-	d := schema.TestResourceDataRaw(t, resourceAlertSource().Schema, map[string]any{
-		"name":              "test-alert-source",
-		"integration_type":  "API",
-		"escalation_policy": "1",
-	})
+	d := testResourceDataForUpdate(t, resourceAlertSource(),
+		map[string]any{
+			"name":              "test-alert-source",
+			"integration_type":  "API",
+			"escalation_policy": "1",
+			"team": []any{
+				map[string]any{"id": 1, "name": "Team 1"},
+				map[string]any{"id": 2, "name": "Team 2"},
+			},
+		},
+		map[string]any{
+			"name":              "test-alert-source",
+			"integration_type":  "API",
+			"escalation_policy": "1",
+		})
 
 	alertSource, err := buildAlertSource(d)
 	if err != nil {
@@ -110,6 +147,41 @@ func TestBuildAlertSource_RemovingAllTeamsSendsEmptyArray(t *testing.T) {
 	}
 	if !strings.Contains(string(payload), `"teams":[]`) {
 		t.Fatalf("expected payload to contain \"teams\":[], got %s", payload)
+	}
+}
+
+// The empty array must stay scoped to alert sources whose team blocks were
+// actually removed. A config that never declared one is not a statement that the
+// alert source has no teams, so an unrelated update must leave whatever is
+// assigned to it elsewhere alone: the field has to be omitted, not sent empty.
+func TestBuildAlertSource_KeepsTeamsWhenNeverDeclared(t *testing.T) {
+	d := testResourceDataForUpdate(t, resourceAlertSource(),
+		map[string]any{
+			"name":              "test-alert-source",
+			"integration_type":  "API",
+			"escalation_policy": "1",
+		},
+		map[string]any{
+			"name":              "test-alert-source-renamed",
+			"integration_type":  "API",
+			"escalation_policy": "1",
+		})
+
+	alertSource, err := buildAlertSource(d)
+	if err != nil {
+		t.Fatalf("unexpected error building alert source: %v", err)
+	}
+
+	if alertSource.Teams != nil {
+		t.Fatalf("expected teams to be omitted, got %v", alertSource.Teams)
+	}
+
+	payload, err := json.Marshal(alertSource)
+	if err != nil {
+		t.Fatalf("unexpected error marshalling alert source: %v", err)
+	}
+	if !strings.Contains(string(payload), `"teams":null`) {
+		t.Fatalf("expected payload to contain \"teams\":null, got %s", payload)
 	}
 }
 

--- a/website/docs/r/alert_source.html.markdown
+++ b/website/docs/r/alert_source.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 - `auto_resolution_timeout` - (Optional) The auto resolution timeout. Allowed values are `PT10M`, `PT20M`, `PT30M`, `PT40M`, `PT50M`, `PT60M`, `PT90M`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `PT12H`, `PT24H` (`H` means hour and `M` means minute).
 - `email` - (Optional) The email address. This option is required if `integration_type` is `EMAIL2`.
 - `support_hours` - (Optional) A [support_hours](#support-hours-arguments) block. This option is allowed if `alert_priority_rule` is `HIGH_DURING_SUPPORT_HOURS` or `LOW_DURING_SUPPORT_HOURS`.
-- `team` - (Optional) One or more [team](#team-arguments) blocks.
+- `team` - (Optional) One or more [team](#team-arguments) blocks. The order in which the blocks are declared is not significant.
 - `summary_template` - (Optional) A summary [template](#template-arguments) block.
 - `details_template` - (Optional) A details [template](#template-arguments) block.
 - `routing_template` - (Optional) A routing [template](#template-arguments) block.


### PR DESCRIPTION
- fix permanent diff on alert source `team` blocks when the declared order differs from the order the API returns them in
- fix removing every `team` block from an alert source not clearing them on the server