### PR TITLE
fix(alert-source): make link_template text optional

### DIFF
--- a/ilert/resource_alert_source.go
+++ b/ilert/resource_alert_source.go
@@ -518,7 +518,7 @@ func resourceAlertSource() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"text": {
 							Type:     schema.TypeString,
-							Required: true,
+							Optional: true,
 						},
 						"href_template": {
 							Type:     schema.TypeList,

--- a/website/docs/r/alert_source.html.markdown
+++ b/website/docs/r/alert_source.html.markdown
@@ -105,7 +105,7 @@ The following arguments are supported:
 
 #### Link template Arguments
 
-- `text` - (Required) The display name for the link.
+- `text` - (Optional) The display name for the link.
 - `href_template` - (Required) A [template](#template-arguments) block.
 
 #### Priority template Arguments


### PR DESCRIPTION
Align schema with the API so link_template.text can be omitted when its value is an empty string.